### PR TITLE
Allow custom element names with multiple dashes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -550,7 +550,8 @@ export class Matcher {
 	}
 }
 
-const kMarkupPattern = /<!--[^]*?(?=-->)-->|<(\/?)([a-z][a-z0-9]*-?[a-z0-9]*)\s*([^>]*?)(\/?)>/ig;
+// https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+const kMarkupPattern = /<!--[^]*?(?=-->)-->|<(\/?)([a-z][-.0-9_a-z]*)\s*([^>]*?)(\/?)>/ig;
 const kAttributePattern = /(^|\s)(id|class)\s*=\s*("([^"]+)"|'([^']+)'|(\S+))/ig;
 const kSelfClosingElements = {
 	meta: true,

--- a/test/html.js
+++ b/test/html.js
@@ -272,4 +272,13 @@ describe('HTML Parser', function () {
 			root.firstChild.tagName.should.eql('my-widget');
 		});
 	});
+
+  describe('Custom Element multiple dash', function () {
+    it('parse "<my-new-widget></my-new-widget>" tagName should be "my-new-widget"', function () {
+
+      var root = parseHTML('<my-new-widget></my-new-widget>');
+
+      root.firstChild.tagName.should.eql('my-new-widget');
+    });
+  });
 });


### PR DESCRIPTION
Hi taoqf,

I found a problem trying to parse html with custom element names,
if the element name has more than one dash in it.

The current HTML spec says a custom element must have **at least** one dash,
but also allows any number of dashes :)

https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name

PR if you want it :)

Andrew.
