### PR TITLE
updating the type of options in the parse function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -742,6 +742,9 @@ const kBlockTextElements = {
 export function parse(data: string, options?: {
 	lowerCaseTagName?: boolean;
 	noFix?: boolean;
+	script?: boolean;
+	style?: boolean;
+	pre?: boolean;
 }) {
 	const root = new HTMLElement(null, {});
 	let currentParent = root;


### PR DESCRIPTION
As per the readme, the parse function supports additional options which are not defined in its type, hence updating the type.