### PR TITLE
improve rawAttributes, fix setAttribute when the value is number

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -432,6 +432,14 @@ export default class HTMLElement extends Node {
 	}
 
 	/**
+	 * Get an attribute
+	 * @return {string} value of the attribute
+	 */
+	getAttribute(key: string) {
+		return this.attributes[key] || null;
+	}
+
+	/**
 	 * Set an attribute value to the HTMLElement
 	 * @param {string} key The attribute name
 	 * @param {string|number} value The value to set, or null / undefined to remove an attribute

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -471,11 +471,11 @@ export default class HTMLElement extends Node {
 	 * @param {Attributes} attributes the new attribute set
 	 */
 	setAttributes(attributes: Attributes) {
-		// Update the this.attributes
+		// Invalidate current this.attributes
 		if (this._attrs) {
 			delete this._attrs;
 		}
-		// Update the raw attributes map
+		// Invalidate current this.rawAttributes
 		if (this._rawAttrs) {
 			delete this._rawAttrs;
 		}

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -421,7 +421,7 @@ export default class HTMLElement extends Node {
 			return this._rawAttrs;
 		const attrs = {} as RawAttributes;
 		if (this.rawAttrs) {
-			const re = /\b([a-z][a-z0-9\-]*)(?:\s*=\s*("(?:[^"]*)"|'(?:[^']*)'|(?:\S+)))?/ig;
+			const re = /\b([a-z][a-z0-9\-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/ig;
 			let match: RegExpExecArray;
 			while (match = re.exec(this.rawAttrs)) {
 				attrs[match[1]] = match[2] || null;
@@ -441,20 +441,15 @@ export default class HTMLElement extends Node {
 		if (this._attrs) {
 			delete this._attrs;
 		}
-		const attrs = this.rawAttributes;	// ref this._rawAttrs
+		const attrs = this.rawAttributes;
 		if (value === undefined || value === null) {
 			delete attrs[key];
 		} else {
-			attrs[key] = JSON.stringify(value);
-			// if (typeof value === 'string') {
-			// 	attrs[key] = JSON.stringify(encode(value));//??? should we encode value here?
-			// } else {
-			// 	attrs[key] = JSON.stringify(value);
-			// }
+			attrs[key] = String(value);
 		}
 		// Update rawString
 		this.rawAttrs = Object.keys(attrs).map((name) => {
-			const val = attrs[name];
+			const val = JSON.stringify(attrs[name]);
 			if (val === undefined || val === null) {
 				return name;
 			} else {

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -445,7 +445,7 @@ export default class HTMLElement extends Node {
 	 * @param {string|number} value The value to set, or null / undefined to remove an attribute
 	 */
 	setAttribute(key: string, value: string | number) {
-		// Update the this.attributes
+		// Invalidate current this.attributes
 		if (this._attrs) {
 			delete this._attrs;
 		}

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -407,7 +407,7 @@ export default class HTMLElement extends Node {
 		const attrs = this.rawAttributes;
 		for (const key in attrs) {
 			const val = attrs[key] || '';
-			this._attrs[key] = decode(val.replace(/^['"]/, '').replace(/['"]$/, ''));
+			this._attrs[key] = decode(val);
 		}
 		return this._attrs;
 	}
@@ -477,12 +477,7 @@ export default class HTMLElement extends Node {
 			if (val === undefined || val === null) {
 				return name;
 			} else {
-				return name + '=' + JSON.stringify(val);
-				// if (typeof val === 'string') {
-				// 	return name + '=' + JSON.stringify(encode(val)); //??? should we encode value here?
-				// } else {
-				// 	return name + '=' + JSON.stringify(val);
-				// }
+				return name + '=' + JSON.stringify(String(val));
 			}
 		}).join(' ');
 	}

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -424,7 +424,7 @@ export default class HTMLElement extends Node {
 			const re = /\b([a-z][a-z0-9\-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/ig;
 			let match: RegExpExecArray;
 			while (match = re.exec(this.rawAttrs)) {
-				attrs[match[1]] = match[2] || null;
+				attrs[match[1]] = match[2] || match[3] || match[4] || null;
 			}
 		}
 		this._rawAttrs = attrs;

--- a/test/html.js
+++ b/test/html.js
@@ -300,8 +300,8 @@ describe('HTML Parser', function () {
 				var root = parseHTML('<p a=12 data-id="!$$&amp;" yAz=\'1\'></p>');
 				root.firstChild.rawAttributes.should.eql({
 					'a': '12',
-					'data-id': '"!$$&amp;"',
-					'yAz': '\'1\''
+					'data-id': '!$$&amp;',
+					'yAz': '1'
 				});
 			});
 		});
@@ -335,7 +335,7 @@ describe('HTML Parser', function () {
 					'a': '12',
 					'b': '13',
 				});
-				root.firstChild.toString().should.eql('<p a=12 b=13></p>');
+				root.firstChild.toString().should.eql('<p a="12" b="13"></p>');
 			});
 			it('should remove an attribute from the element', function () {
 				var root = parseHTML('<p a=12 b=13 c=14></p>');
@@ -344,7 +344,7 @@ describe('HTML Parser', function () {
 				root.firstChild.attributes.should.eql({
 					'a': '12',
 				});
-				root.firstChild.toString().should.eql('<p a=12></p>');
+				root.firstChild.toString().should.eql('<p a="12"></p>');
 			});
 			it('should keep quotes arount value', function () {
 				var root = parseHTML('<p a="12"></p>');

--- a/test/html.js
+++ b/test/html.js
@@ -355,7 +355,7 @@ describe('HTML Parser', function () {
 					'b': '13',
 					'c': '2'
 				});
-				root.firstChild.toString().should.eql('<p a="12" b=13 c="2"></p>');
+				root.firstChild.toString().should.eql('<p a="12" b="13" c="2"></p>');
 			});
 		});
 
@@ -370,7 +370,7 @@ describe('HTML Parser', function () {
 					'c': '12',
 					d: '&&<>foo'
 				});
-				root.firstChild.toString().should.eql('<p c=12 d="&&<>foo"></p>');
+				root.firstChild.toString().should.eql('<p c="12" d="&&<>foo"></p>');
 				// root.firstChild.toString().should.eql('<p c=12 d="&#x26;&#x26;&#x3C;&#x3E;foo"></p>');
 			});
 		});

--- a/test/html.js
+++ b/test/html.js
@@ -326,7 +326,7 @@ describe('HTML Parser', function () {
 				root.firstChild.attributes.should.eql({
 					'a': '13',
 				});
-				root.firstChild.toString().should.eql('<p a=13></p>');
+				root.firstChild.toString().should.eql('<p a="13"></p>');
 			});
 			it('should add an attribute to the element', function () {
 				var root = parseHTML('<p a=12></p>');

--- a/test/html.js
+++ b/test/html.js
@@ -319,6 +319,18 @@ describe('HTML Parser', function () {
 			});
 		});
 
+		describe('#getAttribute', function () {
+			it('should return value of the attribute', function () {
+				var root = parseHTML('<p a="a1b"></p>');
+				root.firstChild.getAttribute('a').should.eql('a1b');
+			});
+
+			it('should return null when there is no such attribute', function () {
+				var root = parseHTML('<p></p>');
+				should.equal(root.firstChild.getAttribute('b'), null);
+			});
+		});
+
 		describe('#setAttribute', function () {
 			it('should edit the attributes of the element', function () {
 				var root = parseHTML('<p a=12></p>');


### PR DESCRIPTION
It improves the behaviour of `rawAttributes` to work as before, so it doesn't return quotes.
Also it fixed the issue of not adding quotes when the set value is number