### PR TITLE
fix: use default export from he with destructering

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1,4 +1,4 @@
-import { decode } from 'he';
+import he from 'he';
 import Node from './node';
 import NodeType from './type';
 import TextNode from './text';
@@ -6,6 +6,8 @@ import Matcher from '../matcher';
 import arr_back from '../back';
 import CommentNode from './comment';
 import parse from '../parse';
+
+const { decode } = he;
 
 export interface KeyAttributes {
 	id?: string;


### PR DESCRIPTION
`he` is typed to provide named esm exports which is not strictly true altough it works with most bundlers. `he` is an UMD package that sets the `module.exports` to an object providing the exports. Some bundlers are only exposing `module.exports` as the default export and no named exports. All bundlers do expose `module.exports` as the default export.

This change allows `node-html-parser` to be compatible with all bundlers by destructering the default export and no using any named exports.