### PR TITLE
add node.replaceWith + add innerHTML setter 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,7 @@
 		"plugin:import/errors",
 		"plugin:import/warnings",
 		"plugin:import/typescript",
-		"prettier",
-		"prettier/@typescript-eslint"
+		"prettier"
 	],
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -218,6 +218,12 @@ export default class HTMLElement extends Node {
 		}).join('');
 	}
 
+	public set innerHTML(content: string) {
+		//const r = parse(content, global.options); // TODO global.options ?
+		const r = parse(content);
+		this.childNodes = r.childNodes.length ? r.childNodes : [new TextNode(content, this)];
+	}
+
 	public set_content(content: string | Node | Node[], options = {} as Options) {
 		if (content instanceof Node) {
 			content = [content];
@@ -226,6 +232,24 @@ export default class HTMLElement extends Node {
 			content = r.childNodes.length ? r.childNodes : [new TextNode(content, this)];
 		}
 		this.childNodes = content;
+	}
+
+	public replaceWith(content: string | Node | Node[]) {
+		if (content instanceof Node) {
+			content = [content];
+		} else if (typeof content == 'string') {
+			//const r = parse(content, global.options); // TODO global.options ?
+			const r = parse(content);
+			content = r.childNodes.length ? r.childNodes : [new TextNode(content, this)];
+		}
+		const idx = this.parentNode.childNodes.findIndex((child) => {
+			return child === this;
+		});
+		this.parentNode.childNodes = [
+			...this.parentNode.childNodes.slice(0, idx),
+			...content,
+			...this.parentNode.childNodes.slice(idx + 1),
+		];
 	}
 
 	public get outerHTML() {
@@ -638,7 +662,7 @@ export default class HTMLElement extends Node {
 		}
 	}
 
-	public get nextElementSibling() {
+	public get nextElementSibling(): Node {
 		if (this.parentNode) {
 			const children = this.parentNode.childNodes;
 			let i = 0;

--- a/test/emptyattribute.js
+++ b/test/emptyattribute.js
@@ -18,14 +18,14 @@ describe('empty attribute', function () {
 		const root = parse('<div class=""></div>');
 		const div = root.firstChild;
 		div.getAttribute('class').should.eql('');
-		div.classNames.length.should.eql(0);
+		div.classList.length.should.eql(0);
 		div.toString().should.eql('<div class=""></div>');
 	});
 	it('attribute name is not exist', function () {
 		const root = parse('<div class=""></div>');
 		const div = root.firstChild;
 		should.equal(div.getAttribute('foo'), undefined);
-		div.classNames.length.should.eql(0);
+		div.classList.length.should.eql(0);
 		div.toString().should.eql('<div class=""></div>');
 	});
 });

--- a/test/html.js
+++ b/test/html.js
@@ -516,13 +516,13 @@ This content should be enclosed within an escaped p tag&lt;br /&gt;
 		it('#toString() should contains id and classnames', function () {
 			const el = new HTMLElement('div', { 'id': 'new_container', 'class': 'container' });
 			el.id.should.eql('new_container');
-			el.classNames.should.deepEqual(['container']);
+			el.classList.values().should.deepEqual(['container']);
 			el.toString().should.eql('<div id="new_container" class="container"></div>');
 		});
 
 		it('#toString() should contains classnames withspaces', function () {
 			const el = new HTMLElement('div', { 'class': 'container1  container2' });
-			el.classNames.should.deepEqual(['container1', 'container2']);
+			el.classList.values().should.deepEqual(['container1', 'container2']);
 			el.toString().should.eql('<div class="container1 container2"></div>');
 		});
 	});


### PR DESCRIPTION
```js
const { parse } = require('node-html-parser')
var root = parse(`\
<html>
  <div class="main">yay</div>
</html>
`);
```

```js
root.querySelector('div.main').innerHTML = 'innerHTML setter was here';
console.log(root.toString());
var result = `\
<html>
  <div class="main">innerHTML setter was here</div>
</html>
`;
```

```js
root.querySelector('div.main').replaceWith('<pre>replaceWith was here</pre>');
console.log(root.toString());
var result = `\
<html>
  <pre>replaceWith was here</pre>
</html>
`;
```

use case: transform custom elements

<details>

```js
var root = parse(`\
<html>
  <some-custom-element class="main">yay</some-custom-element>
</html>
`);
root.querySelectorAll('some-custom-element').forEach(node => {
  //const nodeNew = parse('<div></div>') // not working, we cannot change root node
  const nodeNew = parse('<html><div></div></html>').querySelector('div')

  for (const [name, value] of Object.entries(node.attributes)) {
     nodeNew.setAttribute(name, value);
  }
  // standard DOM method
  //for (let a = 0; a < node.attributes.length; a++) {
  //   const attr = node.attributes[a];
  //   nodeNew.setAttribute(attr.name, attr.value); // copy attribute
  //}
  //const c = nodeNew.getAttribute('class');
  //nodeNew.setAttribute('class', c ? (c + ' ' + node.tagName.toLowerCase()) : c);
  nodeNew.classList.add(node.localName);
  nodeNew.innerHTML = node.innerHTML;
  node.replaceWith(nodeNew);
});
console.log(root.toString());
var result = `\
<html>
  <div class="main some-custom-element">yay</div>
</html>
`;
```

</details>

edit: use classList and localName
todo: maybe implement [element.className](https://developer.mozilla.org/en-US/docs/Web/API/Element/className)
todo: implement [document.createElement](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement)
