### PR TITLE
add source location to nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
 		"ts:amd": "tsc -t es5 -m amd -d false --outFile ./dist/main.js",
 		"ts:esm": "tsc -t esnext -m esnext -d false --outDir ./dist/esm/",
 		"build": "npm run lint && npm run clean && npm run ts:cjs && npm run ts:amd && npm run ts:esm",
+		"build-cjs": "npm run lint && npm run clean && npm run ts:cjs",
+		"build-amd": "npm run lint && npm run clean && npm run ts:amd",
+		"build-esm": "npm run lint && npm run clean && npm run ts:esm",
 		"dev": "tsc -w & mocha -w ./test/*.js",
 		"pretest": "tsc -m commonjs"
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export { default as parse, default } from './parse';
 export { default as valid } from './valid';
 export { default as Node } from './nodes/node';
 export { default as TextNode } from './nodes/text';
-export { default as NodeType } from './nodes/type';
+export { NodeType, SourceLocation } from './nodes/type';

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,7 +1,7 @@
 import { Adapter/*, Predicate*/ } from 'css-select/lib/types';
 import HTMLElement from './nodes/html';
 import Node from './nodes/node';
-import NodeType from './nodes/type';
+import { NodeType } from './nodes/type';
 
 export declare type Predicate = (node: Node) => node is HTMLElement;
 

--- a/src/nodes/comment.ts
+++ b/src/nodes/comment.ts
@@ -1,10 +1,10 @@
 import Node from './node';
-import NodeType from './type';
+import { NodeOptions, NodeType } from './type';
 import HTMLElement from './html';
 
 export default class CommentNode extends Node {
-	public constructor(public rawText: string, parentNode: HTMLElement) {
-		super(parentNode);
+	public constructor(public rawText: string, parentNode: HTMLElement, nodeOptions: NodeOptions) {
+		super(parentNode, nodeOptions);
 	}
 
 	/**

--- a/src/nodes/node.ts
+++ b/src/nodes/node.ts
@@ -1,4 +1,4 @@
-import NodeType from './type';
+import { NodeOptions, NodeType, SourceLocation } from './type';
 import HTMLElement from './html';
 
 /**
@@ -7,11 +7,16 @@ import HTMLElement from './html';
 export default abstract class Node {
 	abstract nodeType: NodeType;
 	public childNodes = [] as Node[];
+	public _source: SourceLocation;
 	abstract text: string;
 	abstract rawText: string;
 	// abstract get rawText(): string;
 	abstract toString(): string;
-	public constructor(public parentNode = null as HTMLElement | null) {
+	public constructor(public parentNode = null as HTMLElement | null, nodeOptions: NodeOptions = {}) {
+		this._source = {
+			start: nodeOptions.start,
+			end: nodeOptions.end,
+		};
 	}
 	public get innerText() {
 		return this.rawText;

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -1,4 +1,4 @@
-import NodeType from './type';
+import { NodeOptions, NodeType } from './type';
 import Node from './node';
 import HTMLElement from './html';
 
@@ -7,8 +7,8 @@ import HTMLElement from './html';
  * @param {string} value [description]
  */
 export default class TextNode extends Node {
-	public constructor(public rawText: string, parentNode: HTMLElement) {
-		super(parentNode);
+	public constructor(public rawText: string, parentNode: HTMLElement, nodeOptions: NodeOptions = {}) {
+		super(parentNode, nodeOptions);
 	}
 
 	/**

--- a/src/nodes/type.ts
+++ b/src/nodes/type.ts
@@ -1,7 +1,15 @@
-enum NodeType {
+export enum NodeType {
 	ELEMENT_NODE = 1,
 	TEXT_NODE = 3,
 	COMMENT_NODE = 8
 }
 
-export default NodeType;
+export type SourceLocation = {
+	start: number,
+	end?: number,
+}
+
+export type NodeOptions = {
+	start?: number,
+	end?: number,
+}


### PR DESCRIPTION
so i can reduce a redundant list of nodes into a unique array

* locations are \*source\* locations, transformations are not tracked
* end positions are missing for close tags

<details>

<summary>demo</summary>

```js
// node-html-parser: `node._source.start` demo
// get a unique and sorted list of parent nodes from multiple child nodes

const { parse } = require('node-html-parser');

const insrc = `\
<html>
  <div id="d1">
    <p class="a">a</p>
  </div>
  <div id="d2">
    <p class="b">b</p>
  </div>
  <div id="d3">
    <p class="a">a</p>
    <p class="b">b</p>
  </div>
  <div id="d4">
    <p class="a">a</p>
    <p class="b">b</p>
  </div>
</html>
`;
// expected result: #d1, #d2, #d3, #d4

const root = parse(insrc);

const childSelectors = ['.a', '.b'];

// use start location as unique key
let parentNodes = new Map();
root.querySelectorAll(childSelectors.join(',')).map(node => {
  const p = node.parentNode;
  parentNodes.set(p._source.start, p);
});

// sort by start location
parentNodes = Array.from(parentNodes.entries()).sort((a, b) => a[0] - b[0]);

// print
for (const [start, parentNode] of parentNodes) {
  console.dir({
    start,
    str_expected: parentNode.toString(),
    str_actual__: (insrc.slice(start, start + 20) + ' ....')
  })
}
```

</details>
