### PR TITLE
Fix id handling

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -131,6 +131,7 @@ export default class HTMLElement extends Node {
 		super(parentNode);
 		this.rawTagName = tagName;
 		this.rawAttrs = rawAttrs || '';
+		this.id = keyAttrs.id || '';
 		this.childNodes = [];
 		this.classList = new DOMTokenList(
 			keyAttrs.class ? keyAttrs.class.split(/\s+/) : [],
@@ -139,7 +140,6 @@ export default class HTMLElement extends Node {
 			)
 		);
 		if (keyAttrs.id) {
-			this.id = keyAttrs.id;
 			if (!rawAttrs) {
 				this.rawAttrs = `id="${keyAttrs.id}"`;
 			}

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -609,6 +609,10 @@ export default class HTMLElement extends Node {
 			}
 			return `${name}=${val}`;
 		}).join(' ');
+		// Update this.id
+		if (key === 'id') {
+			this.id = '';
+		}
 	}
 
 	public hasAttribute(key: string) {
@@ -653,6 +657,10 @@ export default class HTMLElement extends Node {
 			}
 			return `${name}=${val}`;
 		}).join(' ');
+		// Update this.id
+		if (key === 'id') {
+			this.id = value;
+		}
 	}
 
 	/**

--- a/test/112.js
+++ b/test/112.js
@@ -1,0 +1,17 @@
+const { parse, HTMLElement } = require('../dist');
+
+// https://github.com/taoqf/node-html-parser/pull/112
+describe('pull/112', function () {
+	it('this.id is set to an empty string', async function () {
+		const el = new HTMLElement('div', {}, '', null);
+		el.id.should.eql('')
+		should.equal(el.getAttribute('id'), undefined);
+		el.toString().should.eql('<div></div>');
+	});
+	it('this.id is set to the value of keyAttrs', async function () {
+		const el = new HTMLElement('div', { id: 'id' }, 'id="id"', null);
+		el.id.should.eql('id')
+		el.getAttribute('id').should.eql('id')
+		el.toString().should.eql('<div id="id"></div>');
+	});
+});

--- a/test/112.js
+++ b/test/112.js
@@ -14,4 +14,26 @@ describe('pull/112', function () {
 		el.getAttribute('id').should.eql('id')
 		el.toString().should.eql('<div id="id"></div>');
 	});
+	it('#removeAttribute()', async function () {
+		const html = '<div id="id"></div>';
+		const root = parse(html);
+		const el = root.firstChild;
+		el.id.should.eql('id')
+		el.getAttribute('id').should.eql('id')
+		el.removeAttribute('id')
+		el.id.should.eql('')
+		should.equal(el.getAttribute('id'), undefined);
+		el.toString().should.eql('<div></div>');
+	});
+	it('#setAttribute()', async function () {
+		const html = '<div></div>';
+		const root = parse(html);
+		const el = root.firstChild;
+		el.id.should.eql('')
+		should.equal(el.getAttribute('id'), undefined);
+		el.setAttribute('id', 'id')
+		el.id.should.eql('id')
+		el.getAttribute('id').should.eql('id')
+		el.toString().should.eql('<div id="id"></div>');
+	});
 });


### PR DESCRIPTION
- [x] Change `this.id` to required property
Fixed a problem where the `this.id (string)` was sometimes `undefined`.

- [x] Fix `setAttributes()` / `removeAttributes()` to affect `this.id`
I used the behavior of the chrome browser as a reference.

<img width="244" alt="CleanShot 2021-04-11 at 13 01 16@2x" src="https://user-images.githubusercontent.com/1271863/114293247-7c584700-9acf-11eb-893a-4de404ec9119.png">
