### PR TITLE
Add 'sideEffects: false' bundler hint in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,6 @@
 	"bugs": {
 		"url": "https://github.com/taoqf/node-fast-html-parser/issues"
 	},
-	"homepage": "https://github.com/taoqf/node-fast-html-parser"
+	"homepage": "https://github.com/taoqf/node-fast-html-parser",
+	"sideEffects": false
 }


### PR DESCRIPTION
Some bundlers use the 'sideEffects' key in a package's `package.json` as a hint that the package does not have impactful side effects when the module is imported