### PR TITLE
nextElementSibling returns an HTMLElement

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -739,7 +739,7 @@ export default class HTMLElement extends Node {
 		}
 	}
 
-	public get nextElementSibling(): Node {
+	public get nextElementSibling(): HTMLElement {
 		if (this.parentNode) {
 			const children = this.parentNode.childNodes;
 			let i = 0;


### PR DESCRIPTION
The purpose of `nextElementSibling` is to return an `HTMLElement`, not any kind of `Node` ([DOM standard](https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-nextelementsibling)).
The `.tsconfig` disables strict null-checking, so I forgo adding the `null` return type.