### PR TITLE
fix issue #115

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -133,6 +133,42 @@ export default class HTMLElement extends Node {
 
 		return JSON.stringify(attr.replace(/"/g, '&quot;'));
 	}
+
+  /**
+   * Trim all whitespace except single leading/trailing non-breaking space
+   * @param text string to trim
+   * @returns {string} trimmed value
+   * @private
+   */
+	private trimTextNodeWhitespace(text: string): string {
+    let i = 0;
+    let startPos;
+    let endPos;
+
+    while (i >= 0 && i < text.length) {
+      if (/\S/.test(text[i])) {
+        if (startPos === undefined) {
+          startPos = i;
+          i = text.length;
+        } else {
+          endPos = i;
+          i = void 0;
+        }
+      }
+
+      if (startPos === undefined) i++;
+      else i--;
+    }
+
+    if (startPos === undefined) startPos = 0;
+    if (endPos === undefined) endPos = text.length - 1;
+
+    const hasLeadingSpace = startPos > 0 && /[^\S\r\n]/.test(text[startPos-1]);
+    const hasTrailingSpace = endPos < (text.length - 1) && /[^\S\r\n]/.test(text[endPos+1]);
+
+    return (hasLeadingSpace ? ' ' : '') + text.slice(startPos, endPos + 1) + (hasTrailingSpace ? ' ' : '');
+  }
+
 	/**
 	 * Creates an instance of HTMLElement.
 	 * @param keyAttrs	id and class attribute
@@ -401,7 +437,7 @@ export default class HTMLElement extends Node {
 				if ((node as TextNode).isWhitespace) {
 					return;
 				}
-				node.rawText = node.rawText.trim();
+				node.rawText = this.trimTextNodeWhitespace(node.rawText);
 			} else if (node.nodeType === NodeType.ELEMENT_NODE) {
 				(node as HTMLElement).removeWhitespace();
 			}

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -134,41 +134,6 @@ export default class HTMLElement extends Node {
 		return JSON.stringify(attr.replace(/"/g, '&quot;'));
 	}
 
-  /**
-   * Trim all whitespace except single leading/trailing non-breaking space
-   * @param text string to trim
-   * @returns {string} trimmed value
-   * @private
-   */
-	private trimTextNodeWhitespace(text: string): string {
-    let i = 0;
-    let startPos;
-    let endPos;
-
-    while (i >= 0 && i < text.length) {
-      if (/\S/.test(text[i])) {
-        if (startPos === undefined) {
-          startPos = i;
-          i = text.length;
-        } else {
-          endPos = i;
-          i = void 0;
-        }
-      }
-
-      if (startPos === undefined) i++;
-      else i--;
-    }
-
-    if (startPos === undefined) startPos = 0;
-    if (endPos === undefined) endPos = text.length - 1;
-
-    const hasLeadingSpace = startPos > 0 && /[^\S\r\n]/.test(text[startPos-1]);
-    const hasTrailingSpace = endPos < (text.length - 1) && /[^\S\r\n]/.test(text[endPos+1]);
-
-    return (hasLeadingSpace ? ' ' : '') + text.slice(startPos, endPos + 1) + (hasTrailingSpace ? ' ' : '');
-  }
-
 	/**
 	 * Creates an instance of HTMLElement.
 	 * @param keyAttrs	id and class attribute
@@ -296,7 +261,7 @@ export default class HTMLElement extends Node {
 					// Whitespace node, postponed output
 					currentBlock.prependWhitespace = true;
 				} else {
-					let text = node.text;
+					let text = (<TextNode>node).trimmedText;
 					if (currentBlock.prependWhitespace) {
 						text = ` ${text}`;
 						currentBlock.prependWhitespace = false;
@@ -437,7 +402,7 @@ export default class HTMLElement extends Node {
 				if ((node as TextNode).isWhitespace) {
 					return;
 				}
-				node.rawText = this.trimTextNodeWhitespace(node.rawText);
+				node.rawText = (<TextNode>node).trimmedText;
 			} else if (node.nodeType === NodeType.ELEMENT_NODE) {
 				(node as HTMLElement).removeWhitespace();
 			}

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -17,6 +17,45 @@ export default class TextNode extends Node {
 	 */
 	public nodeType = NodeType.TEXT_NODE;
 
+	private _trimmedText?: string;
+
+  /**
+   * Returns text with all whitespace trimmed except single leading/trailing non-breaking space
+   */
+	public get trimmedText() {
+	  if (this._trimmedText !== undefined) return this._trimmedText;
+
+	  const text = this.rawText;
+    let i = 0;
+    let startPos;
+    let endPos;
+
+    while (i >= 0 && i < text.length) {
+      if (/\S/.test(text[i])) {
+        if (startPos === undefined) {
+          startPos = i;
+          i = text.length;
+        } else {
+          endPos = i;
+          i = void 0;
+        }
+      }
+
+      if (startPos === undefined) i++;
+      else i--;
+    }
+
+    if (startPos === undefined) startPos = 0;
+    if (endPos === undefined) endPos = text.length - 1;
+
+    const hasLeadingSpace = startPos > 0 && /[^\S\r\n]/.test(text[startPos-1]);
+    const hasTrailingSpace = endPos < (text.length - 1) && /[^\S\r\n]/.test(text[endPos+1]);
+
+    this._trimmedText = (hasLeadingSpace ? ' ' : '') + text.slice(startPos, endPos + 1) + (hasTrailingSpace ? ' ' : '');
+
+    return this._trimmedText;
+  }
+
 	/**
 	 * Get unescaped text value of current node and its children.
 	 * @return {string} text content

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -19,42 +19,42 @@ export default class TextNode extends Node {
 
 	private _trimmedText?: string;
 
-  /**
-   * Returns text with all whitespace trimmed except single leading/trailing non-breaking space
-   */
+	/**
+	 * Returns text with all whitespace trimmed except single leading/trailing non-breaking space
+	 */
 	public get trimmedText() {
-	  if (this._trimmedText !== undefined) return this._trimmedText;
+		if (this._trimmedText !== undefined) return this._trimmedText;
 
-	  const text = this.rawText;
-    let i = 0;
-    let startPos;
-    let endPos;
+		const text = this.rawText;
+		let i = 0;
+		let startPos;
+		let endPos;
 
-    while (i >= 0 && i < text.length) {
-      if (/\S/.test(text[i])) {
-        if (startPos === undefined) {
-          startPos = i;
-          i = text.length;
-        } else {
-          endPos = i;
-          i = void 0;
-        }
-      }
+		while (i >= 0 && i < text.length) {
+			if (/\S/.test(text[i])) {
+				if (startPos === undefined) {
+					startPos = i;
+					i = text.length;
+				} else {
+					endPos = i;
+					i = void 0;
+				}
+			}
 
-      if (startPos === undefined) i++;
-      else i--;
-    }
+			if (startPos === undefined) i++;
+			else i--;
+		}
 
-    if (startPos === undefined) startPos = 0;
-    if (endPos === undefined) endPos = text.length - 1;
+		if (startPos === undefined) startPos = 0;
+		if (endPos === undefined) endPos = text.length - 1;
 
-    const hasLeadingSpace = startPos > 0 && /[^\S\r\n]/.test(text[startPos-1]);
-    const hasTrailingSpace = endPos < (text.length - 1) && /[^\S\r\n]/.test(text[endPos+1]);
+		const hasLeadingSpace = startPos > 0 && /[^\S\r\n]/.test(text[startPos-1]);
+		const hasTrailingSpace = endPos < (text.length - 1) && /[^\S\r\n]/.test(text[endPos+1]);
 
-    this._trimmedText = (hasLeadingSpace ? ' ' : '') + text.slice(startPos, endPos + 1) + (hasTrailingSpace ? ' ' : '');
+		this._trimmedText = (hasLeadingSpace ? ' ' : '') + text.slice(startPos, endPos + 1) + (hasTrailingSpace ? ' ' : '');
 
-    return this._trimmedText;
-  }
+		return this._trimmedText;
+	}
 
 	/**
 	 * Get unescaped text value of current node and its children.

--- a/test/html.js
+++ b/test/html.js
@@ -202,7 +202,7 @@ describe('HTML Parser', function () {
 
 				const p = new HTMLElement('p', {}, '', root);
 				p.appendChild(new HTMLElement('h5', {}, ''))
-					.appendChild(new TextNode('123'));
+					.appendChild(Object.assign(new TextNode('123'), { _trimmedText: '123' }));
 
 				root.firstChild.removeWhitespace().should.eql(p);
 			});

--- a/test/html.js
+++ b/test/html.js
@@ -126,10 +126,10 @@ describe('HTML Parser', function () {
 			const script = root.firstChild;
 			const style = root.lastChild;
 			script.childNodes.should.not.be.empty;
-			script.childNodes.should.eql([new TextNode('1', script)]);
+			script.childNodes.should.eql([ new TextNode('1', script) ]);
 			script.text.should.eql('1');
 			style.childNodes.should.not.be.empty;
-			style.childNodes.should.eql([new TextNode('2&amp;', style)]);
+			style.childNodes.should.eql([ new TextNode('2&amp;', style) ]);
 			style.text.should.eql('2&');
 			style.rawText.should.eql('2&amp;');
 		});
@@ -198,11 +198,16 @@ describe('HTML Parser', function () {
 
 		describe('#removeWhitespace()', function () {
 			it('should remove whitespaces while preserving nodes with content', function () {
-				const root = parseHTML('<p> \r \n  \t <h5>123</h5></p>');
+				const root = parseHTML('<p> \r \n  \t <h5>  123  </h5></p>');
+
+				const textNode = new TextNode('  123  ');
+				textNode.rawText = textNode.trimmedText;
+				textNode.rawText.should.eql(' 123 ');
 
 				const p = new HTMLElement('p', {}, '', root);
-				p.appendChild(new HTMLElement('h5', {}, ''))
-					.appendChild(Object.assign(new TextNode('123'), { _trimmedText: '123' }));
+				p
+					.appendChild(new HTMLElement('h5', {}, ''))
+					.appendChild(textNode);
 
 				root.firstChild.removeWhitespace().should.eql(p);
 			});

--- a/test/html.js
+++ b/test/html.js
@@ -208,10 +208,10 @@ describe('HTML Parser', function () {
 			});
 
 			it('should preserve legitimate leading/trailing whitespace in TextNode', function () {
-			  parseHTML('<p>Hello  <em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql('Hello World!');
-			  parseHTML('<p>\t\nHello\n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql('HelloWorld!');
-			  parseHTML('<p>\t\n  Hello \n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql(' Hello World!');
-      });
+				parseHTML('<p>Hello  <em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql('Hello World!');
+				parseHTML('<p>\t\nHello\n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql('HelloWorld!');
+				parseHTML('<p>\t\n  Hello \n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql(' Hello World!');
+			});
 		});
 
 		describe('#rawAttributes', function () {

--- a/test/html.js
+++ b/test/html.js
@@ -198,7 +198,7 @@ describe('HTML Parser', function () {
 
 		describe('#removeWhitespace()', function () {
 			it('should remove whitespaces while preserving nodes with content', function () {
-				const root = parseHTML('<p> \r \n  \t <h5> 123 </h5></p>');
+				const root = parseHTML('<p> \r \n  \t <h5>123</h5></p>');
 
 				const p = new HTMLElement('p', {}, '', root);
 				p.appendChild(new HTMLElement('h5', {}, ''))
@@ -206,6 +206,12 @@ describe('HTML Parser', function () {
 
 				root.firstChild.removeWhitespace().should.eql(p);
 			});
+
+			it('should preserve legitimate leading/trailing whitespace in TextNode', function () {
+			  parseHTML('<p>Hello  <em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql('Hello World!');
+			  parseHTML('<p>\t\nHello\n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql('HelloWorld!');
+			  parseHTML('<p>\t\n  Hello \n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql(' Hello World!');
+      });
 		});
 
 		describe('#rawAttributes', function () {


### PR DESCRIPTION
## Abstract

The following PR takes a holistic approach to mitigating issue #115 by implementing HTML-specific trim functionality, where necessary. Its aim is to provide a more accurate correction for the `trim()` issue by replicating trim, while explicitly preserving only single leading or trailing non-breaking whitespace, where present.

## Background

In addition to the already corrected area (`structuredText`) a second affected area was found.

The purpose of `HTMLElement#removeWhitespace` is to remove unnecessary whitespace nodes and otherwise cleanup the text. To do this, it calls `trim()` on `TextNode` rawText. Unfortuntately, this is too greedy.

Trim rightly removes repeating spaces, tabs, and line-breaks, which are often simply junk from multi-line HTML formatting. Unfortunately, it also removes legitimate, single, non-breaking space at the beginning or end of the text in a `TextNode`.

Put more simply, it's overcorrecting in some scenarios. Here are some examples:

```html
<p>Hello <em>world!</em></p>` <!-- Desired: 'Hello world!' Actual: 'Helloworld!` -->
<p>Hello\n\r\r<em>world </em>!</p>` <!-- Desired: 'Helloworld !' Actual: 'Helloworld!` -->
<p>Hello\n\r\t<em>world   </em>!</p>` <!-- Desired: 'Hello world !' Actual: 'Helloworld!` -->
```

## Solution

I've replaced the two calls to `trim()` with a cached accessor on each `TextNode`. The accessor performs the same action as trim, with the exception that it will allow a single non-breaking space before and after the text, if one is present.

## Associated Issues
taoqf/node-html-parser#115
crosstype/node-html-markdown#9