### PR TITLE
Add source location to nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"build-esm": "npm run lint && npm run clean && npm run ts:esm",
 		"dev": "tsc -w & mocha -w ./test/*.js",
 		"pretest": "tsc -m commonjs",
-		"release": "yarn build && np"
+		"release": "npm run build && np",
+		"prepare": "npm run build"
 	},
 	"keywords": [
 		"parser",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
 		"ts:amd": "tsc -t es5 -m amd -d false --outFile ./dist/main.js",
 		"ts:esm": "tsc -t esnext -m esnext -d false --outDir ./dist/esm/",
 		"build": "npm run lint && npm run clean && npm run ts:cjs && npm run ts:amd && npm run ts:esm",
+		"build-cjs": "npm run lint && npm run clean && npm run ts:cjs",
+		"build-amd": "npm run lint && npm run clean && npm run ts:amd",
+		"build-esm": "npm run lint && npm run clean && npm run ts:esm",
 		"dev": "tsc -w & mocha -w ./test/*.js",
 		"pretest": "tsc -m commonjs",
 		"release": "yarn build && np"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ export { default as parse, default } from './parse';
 export { default as valid } from './valid';
 export { default as Node } from './nodes/node';
 export { default as TextNode } from './nodes/text';
-export { default as NodeType } from './nodes/type';
+export { NodeType, SourceLocation } from './nodes/type';

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,7 +1,7 @@
 import { Adapter/*, Predicate*/ } from 'css-select/lib/types';
 import HTMLElement from './nodes/html';
 import Node from './nodes/node';
-import NodeType from './nodes/type';
+import { NodeType } from './nodes/type';
 
 export declare type Predicate = (node: Node) => node is HTMLElement;
 

--- a/src/nodes/comment.ts
+++ b/src/nodes/comment.ts
@@ -1,10 +1,10 @@
 import Node from './node';
-import NodeType from './type';
+import { NodeOptions, NodeType } from './type';
 import HTMLElement from './html';
 
 export default class CommentNode extends Node {
-	public constructor(public rawText: string, parentNode: HTMLElement) {
-		super(parentNode);
+	public constructor(public rawText: string, parentNode: HTMLElement, nodeOptions: NodeOptions) {
+		super(parentNode, nodeOptions);
 	}
 
 	/**

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -6,6 +6,7 @@ import TextNode from './text';
 import Matcher from '../matcher';
 import arr_back from '../back';
 import CommentNode from './comment';
+import parse from '../parse';
 
 // const { decode } = he;
 
@@ -154,11 +155,13 @@ export default class HTMLElement extends Node {
 			)
 		);
 		if (keyAttrs.id) {
+			this.id = keyAttrs.id;
 			if (!rawAttrs) {
 				this.rawAttrs = `id="${keyAttrs.id}"`;
 			}
 		}
 		if (keyAttrs.class) {
+			this.classNames = keyAttrs.class.split(/\s+/);
 			if (!rawAttrs) {
 				const cls = `class="${this.classList.toString()}"`;
 				if (this.rawAttrs) {

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1,7 +1,7 @@
 import he from 'he';
 import { selectAll, selectOne } from 'css-select';
 import Node from './node';
-import NodeType from './type';
+import { NodeOptions, NodeType } from './type';
 import TextNode from './text';
 import Matcher from '../matcher';
 import arr_back from '../back';
@@ -141,8 +141,8 @@ export default class HTMLElement extends Node {
 	 *
 	 * @memberof HTMLElement
 	 */
-	public constructor(tagName: string, keyAttrs: KeyAttributes, private rawAttrs = '', parentNode: HTMLElement | null) {
-		super(parentNode);
+	public constructor(tagName: string, keyAttrs: KeyAttributes, private rawAttrs = '', parentNode: HTMLElement | null, nodeOptions: NodeOptions = {}) {
+		super(parentNode, nodeOptions);
 		this.rawTagName = tagName;
 		this.rawAttrs = rawAttrs || '';
 		this.id = keyAttrs.id || '';
@@ -963,12 +963,26 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 	let match: RegExpExecArray;
 	// https://github.com/taoqf/node-html-parser/issues/38
 	data = `<${frameflag}>${data}</${frameflag}>`;
+	const dataOffset = `<${frameflag}>`.length;
+	const dataLastIndex = data.length - `</${frameflag}>`.length - 1;
+
+	function nodeArgs(start: number, end: number) {
+		const text = data.substring(start, end);
+		const nodeOptions = {
+			start: start - dataOffset,
+			end: end - dataOffset,
+		};
+		return { text, nodeOptions };
+	}
+
 	while ((match = kMarkupPattern.exec(data))) {
+		// match[0] is open or close tag, without content
+		//console.dir({ ...match, input: undefined }); // debug
 		if (lastTextPos > -1) {
 			if (lastTextPos + match[0].length < kMarkupPattern.lastIndex) {
 				// if has content
-				const text = data.substring(lastTextPos, kMarkupPattern.lastIndex - match[0].length);
-				currentParent.appendChild(new TextNode(text, currentParent));
+				const { text, nodeOptions } = nodeArgs(lastTextPos, match.index);
+				currentParent.appendChild(new TextNode(text, currentParent, nodeOptions));
 			}
 		}
 		lastTextPos = kMarkupPattern.lastIndex;
@@ -979,8 +993,11 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 			// this is a comment
 			if (options.comment) {
 				// Only keep what is in between <!-- and -->
-				const text = data.substring(lastTextPos - 3, lastTextPos - match[0].length + 4);
-				currentParent.appendChild(new CommentNode(text, currentParent));
+				const { text, nodeOptions } = nodeArgs(
+					lastTextPos - 3,
+					lastTextPos - match[0].length + 4
+				);
+				currentParent.appendChild(new CommentNode(text, currentParent, nodeOptions));
 			}
 			continue;
 		}
@@ -988,10 +1005,12 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 			match[2] = match[2].toLowerCase();
 		}
 		if (!match[1]) {
-			// not </ tags
+			// open tag
 			const attrs = {};
-			for (let attMatch; (attMatch = kAttributePattern.exec(match[3]));) {
-				attrs[attMatch[2].toLowerCase()] = attMatch[4] || attMatch[5] || attMatch[6];
+			if (match[3]) {
+				for (let attMatch; (attMatch = kAttributePattern.exec(match[3]));) {
+					attrs[attMatch[2].toLowerCase()] = attMatch[4] || attMatch[5] || attMatch[6];
+				}
 			}
 
 			const tagName = currentParent.rawTagName as 'LI' | 'P' | 'B' | 'TD' | 'TH' | 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'li' | 'p' | 'b' | 'td' | 'th' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
@@ -1001,9 +1020,14 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 					currentParent = arr_back(stack);
 				}
 			}
+			const nodeOptions = {
+				start: match.index - dataOffset,
+				//end: -1, // end is unknown here
+			};
 			// ignore container tag we add above
 			// https://github.com/taoqf/node-html-parser/issues/38
-			currentParent = currentParent.appendChild(new HTMLElement(match[2], attrs, match[3], null));
+			//console.dir({ new_HTMLElement: { name: match[2], attrs, attrRaw: match[3], parent: null, nodeOptions } }); // debug
+			currentParent = currentParent.appendChild(new HTMLElement(match[2], attrs, match[3], null, nodeOptions));
 			stack.push(currentParent);
 			if (is_block_text_element(match[2])) {
 				// a little test to find next </script> or </style> ...
@@ -1016,14 +1040,19 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 				})();
 				if (element_should_be_ignore(match[2])) {
 					let text: string;
+					const nodeOptions = {
+						start: kMarkupPattern.lastIndex - dataOffset,
+						end: dataLastIndex, // TODO verify
+					};
 					if (index === -1) {
 						// there is no matching ending for the text element.
 						text = data.substr(kMarkupPattern.lastIndex);
 					} else {
 						text = data.substring(kMarkupPattern.lastIndex, index);
+						nodeOptions.end = index - dataOffset;
 					}
 					if (text.length > 0) {
-						currentParent.appendChild(new TextNode(text, currentParent));
+						currentParent.appendChild(new TextNode(text, currentParent, nodeOptions));
 					}
 				}
 				if (index === -1) {

--- a/src/nodes/node.ts
+++ b/src/nodes/node.ts
@@ -1,4 +1,4 @@
-import NodeType from './type';
+import { NodeOptions, NodeType, SourceLocation } from './type';
 import HTMLElement from './html';
 
 /**
@@ -7,11 +7,16 @@ import HTMLElement from './html';
 export default abstract class Node {
 	abstract nodeType: NodeType;
 	public childNodes = [] as Node[];
+	public _source: SourceLocation;
 	abstract text: string;
 	abstract rawText: string;
 	// abstract get rawText(): string;
 	abstract toString(): string;
-	public constructor(public parentNode = null as HTMLElement | null) {
+	public constructor(public parentNode = null as HTMLElement | null, nodeOptions: NodeOptions = {}) {
+		this._source = {
+			start: nodeOptions.start,
+			end: nodeOptions.end,
+		};
 	}
 	public get innerText() {
 		return this.rawText;

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -1,4 +1,4 @@
-import NodeType from './type';
+import { NodeOptions, NodeType } from './type';
 import Node from './node';
 import HTMLElement from './html';
 
@@ -7,8 +7,8 @@ import HTMLElement from './html';
  * @param {string} value [description]
  */
 export default class TextNode extends Node {
-	public constructor(public rawText: string, parentNode: HTMLElement) {
-		super(parentNode);
+	public constructor(public rawText: string, parentNode: HTMLElement, nodeOptions: NodeOptions = {}) {
+		super(parentNode, nodeOptions);
 	}
 
 	/**

--- a/src/nodes/type.ts
+++ b/src/nodes/type.ts
@@ -1,7 +1,15 @@
-enum NodeType {
+export enum NodeType {
 	ELEMENT_NODE = 1,
 	TEXT_NODE = 3,
 	COMMENT_NODE = 8
 }
 
-export default NodeType;
+export type SourceLocation = {
+	start: number,
+	end?: number,
+}
+
+export type NodeOptions = {
+	start?: number,
+	end?: number,
+}


### PR DESCRIPTION
continue #107 

use case: detect indent of node, so i can insert new nodes and preserve the indent level

status: tests are failing

sample code: wrap text node in a language-switch container

```js
const nodeStart = node._source.start;
const lineStart = html.lastIndexOf('\n', nodeStart) + 1;
const indent = html.slice(lineStart, nodeStart).match(/^\s*/)[0];

node.classList.add('langs');
node.innerHTML = node.innerHTML.includes('\n')
  ? ([
      '',
      `  <div lang="en">`,
      `    ${node.innerHTML}`,
      `  </div>`,
      '',
    ].join('\n').replace(/\n/g, `\n${indent}`))
  : ([
      '',
      `  <div lang="en">${node.innerHTML}</div>`,
      '',
    ].join('\n').replace(/\n/g, `\n${indent}`))
;
```

small edits:

* use `npm run build` instead of `yarn build`
* add prepare script = duplicate of #125 
* add `classNames` setter
* move class string parsing to `DOMTokenList._fromString`
* add per-target build scripts for faster development
* not sure why i added `this.id = keyAttrs.id`
* `this.rawAttrs` may need more work -> `generate class and rawAttrs only on demand?`
