### PR TITLE
Bump css-select to ^4.1.3 to resolve https://npmjs.com/advisories/1754

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"registry": "https://registry.npmjs.org"
 	},
 	"dependencies": {
-		"css-select": "^3.1.2",
+		"css-select": "^4.1.3",
 		"he": "1.2.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
`css-what` which is a dependency of `css-select` have a vulnerability is versions prior to 5.0.1. `css-select` seem to have used ^5.0.0 of `css-what` since version 4 (https://github.com/fb55/css-select/blob/v4.0.0/package.json#L25), so I bumped the dependency here to the latest of `css-select` and all tests seem to pass so hopefully all is good.

If anyone think of any more testing needed part from existing test passing, I'll be happy to assist.