### PR TITLE
Fix types

### DIFF
--- a/src/nodes/comment.ts
+++ b/src/nodes/comment.ts
@@ -17,11 +17,11 @@ export default class CommentNode extends Node {
 	 * Get unescaped text value of current node and its children.
 	 * @return {string} text content
 	 */
-	public get text() {
+	public get text(): string {
 		return this.rawText;
 	}
 
-	public toString() {
+	public toString(): string {
 		return `<!--${this.rawText}-->`;
 	}
 }


### PR DESCRIPTION
When I try to build, I get:
```
node_modules/node-html-parser/dist/nodes/comment.d.ts:17:17 - error TS1110: Type expected.
17     toString(): `<!--${string}-->`;
                   ~~~~~~~
node_modules/node-html-parser/dist/nodes/comment.d.ts:18:1 - error TS1128: Declaration or statement expected.
18 }
```

The problem is very easy to fix telling to typescript the right type in the function's definition.