### PR TITLE
feat: Add range to nodes and fix whitespace issue (fixes #137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,7 @@ Get all attributes of current element. **Notice: do not try to change the return
 ### HTMLElement#classList
 
 Get all attributes of current element. **Notice: do not try to change the returned value.**
+
+### HTMLElement#range
+
+Corresponding source code start and end indexes (ie [ 0, 40 ])

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"htmlparser-benchmark": "^1.1.3",
 		"htmlparser2": "^6.0.0",
 		"mocha": "latest",
+		"mocha-each": "^2.0.1",
 		"np": "latest",
 		"parse5": "^6.0.1",
 		"should": "latest",

--- a/src/nodes/comment.ts
+++ b/src/nodes/comment.ts
@@ -3,8 +3,8 @@ import NodeType from './type';
 import HTMLElement from './html';
 
 export default class CommentNode extends Node {
-	public constructor(public rawText: string, parentNode: HTMLElement) {
-		super(parentNode);
+	public constructor(public rawText: string, parentNode: HTMLElement, range?: [ number, number ]) {
+		super(parentNode, range);
 	}
 
 	/**

--- a/src/nodes/node.ts
+++ b/src/nodes/node.ts
@@ -8,11 +8,21 @@ import HTMLElement from './html';
 export default abstract class Node {
 	abstract nodeType: NodeType;
 	public childNodes = [] as Node[];
+	public range: readonly [ number, number ];
 	abstract text: string;
 	abstract rawText: string;
 	// abstract get rawText(): string;
 	abstract toString(): string;
-	public constructor(public parentNode = null as HTMLElement | null) {
+	public constructor(
+		public parentNode = null as HTMLElement | null,
+		range?: [ number, number ]
+	) {
+		Object.defineProperty(this, 'range', {
+			enumerable: false,
+			writable: true,
+			configurable: true,
+			value: range ?? [ -1, -1 ]
+		});
 	}
 	public get innerText() {
 		return this.rawText;

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -8,8 +8,8 @@ import NodeType from './type';
  * @param {string} value [description]
  */
 export default class TextNode extends Node {
-	public constructor(rawText: string, parentNode: HTMLElement) {
-		super(parentNode);
+	public constructor(rawText: string, parentNode: HTMLElement, range?: [ number, number ]) {
+		super(parentNode, range);
 		this._rawText = rawText;
 	}
 

--- a/test/node-ranges.js
+++ b/test/node-ranges.js
@@ -1,0 +1,85 @@
+const { parse, HTMLElement, TextNode, CommentNode } = require('../dist');
+const hp2 = require('htmlparser2')
+const mochaEach = require('mocha-each');
+
+// Use https://astexplorer.net/ to compare
+const html = `
+Leading text
+
+
+<div>
+  <p>Text Content</p>
+  Goes Here
+</div>
+<input name="hello">
+<!-- comment -->
+<style>
+  .abc {
+    display: none
+  }
+</style>
+<pre>
+  block Text
+</pre>
+<span>The space between us</span>      <span>is vast</span>
+Closing text
+`;
+
+function prepare() {
+  const nodeMeta = [];
+  const abbreviate = (s, maxLen = 8) =>
+    (s.length > maxLen ? s.slice(0, maxLen) + '...' : s).replace(/(\r?\n)/g, '\\n');
+
+  // Parse AST
+  const hp2ast = hp2.parseDocument(html, { withEndIndices: true, withStartIndices: true });
+  const ast = parse(html, { comment: true });
+
+  // Prepare flatNodes
+  ast.childNodes.forEach((n, idx, arr) => walk(arr, idx, hp2ast.childNodes));
+
+  return { nodeMeta, ast, hp2ast };
+
+  function walk(nodeArr, idx, mirrorArr) {
+    const node = nodeArr[idx];
+    const mirrorNode = mirrorArr[idx];
+
+    const label = mirrorNode.type !== 'tag' ? `<${mirrorNode.type}: '${abbreviate(node.text)}'>` : node.tagName;
+    nodeMeta.push([ label, node, mirrorNode ]);
+
+    node.childNodes.forEach((n, idx, arr) => walk(arr, idx, mirrorNode.childNodes));
+  }
+}
+
+// See: https://github.com/taoqf/node-html-parser/issues/137
+describe(`Elements ranges`, function () {
+  const { nodeMeta, ast } = prepare();
+
+  before(() => {
+    // Pre-check to make sure configured html is not altered
+    ast.childNodes.length.should.be.greaterThan(2);
+  });
+
+  describe(`parsed elements created with proper ranges`, () => {
+    mochaEach(nodeMeta).it(`%s`, (label, node, hp2Node) => {
+      /* Ensure we have the right node mapping */
+      const expectedProto = hp2Node.type === 'comment' ? CommentNode :
+                            hp2Node.type === 'text' ? TextNode :
+                            HTMLElement;
+      Object.getPrototypeOf(node).constructor.should.eql(expectedProto);
+      if (expectedProto === HTMLElement) node.tagName.toLocaleLowerCase().should.eql(hp2Node.name.toLocaleLowerCase());
+
+      // Check range
+      node.range.should.eql([ hp2Node.startIndex, hp2Node.endIndex + 1 ]);
+    });
+  });
+
+  it(`new nodes are created with [ -1, -1 ] range by default`, () => {
+    const nodes = [
+      new HTMLElement('B', {}, '', null),
+      new TextNode('text', null),
+      new CommentNode('text', null)
+    ];
+
+    for (const node of nodes) node.range.should.eql([ -1, -1 ]);
+  });
+});

--- a/test/parse.js
+++ b/test/parse.js
@@ -18,4 +18,9 @@ describe('HTML Parser', function () {
 		const root = parse('<!DOCTYPE html><html lang="en"><head></head><body><script id="storeFinder" type="application/json">{"key":true}</script></body></html>');
 		root.toString().should.eql('<!DOCTYPE html><html lang="en"><head></head><body><script id="storeFinder" type="application/json">{"key":true}</script></body></html>');
 	});
+	// See: https://github.com/taoqf/node-html-parser/issues/137
+	it(`parses all whitespace`, () => {
+		const root = parse(`<span>test1</span> <span>test2</span>\n<span>test3</span>\r\n<span>test4</span>`);
+		root.text.should.eql('test1 test2\ntest3\r\ntest4');
+	});
 });


### PR DESCRIPTION
## Abstract

It turns out that other AST parsers _do_ create a `TextNode` for all whitespace (see https://astexplorer.net) The only which does not is the parser for angular templates, which it likely does because it's used in a very narrow context.

The issue ended up being that `node-html-parser` actually does create a `TextNode` for whitespace, but there were some cases in which that was failing to happen. This caused the behaviour to differ from other parsers and is the root of the issue laid out in #137.

## Features / Fixes

- Added `range` property to nodes
- Fixed whitespace not being created issue (solves #137 & #126)

## Code Changes

- Cleaned up parser code to make it understandable and slightly more efficient
- Added comprehensive test for node ranges
- Added basic whitespace parser test

## Version

*v4.1.0*

Because a feature was added, I recommend bumping minor version.

## Related

- #126
- https://github.com/crosstype/node-html-markdown/issues/16
- #137