### PR TITLE
Fix 144

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1083,7 +1083,7 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 			}
 
 			// Prevent nested A tags by terminating the last A and starting a new one : see issue #144
-			if (match[2] === 'a') {
+			if (match[2] === 'a' || match[2] === 'A') {
 				if (noNestedTagIndex !== undefined) {
 					stack.splice(noNestedTagIndex);
 					currentParent = arr_back(stack);
@@ -1128,7 +1128,7 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 		// Handle closing tags or self-closed elements (ie </tag> or <br>)
 		if (match[1] || match[4] || kSelfClosingElements[match[2]]) {
 			while (true) {
-				if (match[2] === 'a') noNestedTagIndex = undefined;
+				if (match[2] === 'a' || match[2] === 'A') noNestedTagIndex = undefined;
 				if (currentParent.rawTagName === match[2]) {
 					// Update range end for closed tag
 					(<[number, number]>currentParent.range)[1] = createRange(-1, Math.max(lastTextPos, tagEndPos))[1];

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1082,14 +1082,14 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 				}
 			}
 
-      // Prevent nested A tags by terminating the last A and starting a new one : see issue #144
+			// Prevent nested A tags by terminating the last A and starting a new one : see issue #144
 			if (match[2] === 'a') {
-        if (noNestedTagIndex !== undefined) {
-          stack.splice(noNestedTagIndex);
-          currentParent = arr_back(stack);
-        }
-        noNestedTagIndex = stack.length;
-      }
+				if (noNestedTagIndex !== undefined) {
+					stack.splice(noNestedTagIndex);
+					currentParent = arr_back(stack);
+				}
+				noNestedTagIndex = stack.length;
+			}
 
 			const tagEndPos = kMarkupPattern.lastIndex;
 			const tagStartPos = tagEndPos - match[0].length;
@@ -1128,7 +1128,7 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 		// Handle closing tags or self-closed elements (ie </tag> or <br>)
 		if (match[1] || match[4] || kSelfClosingElements[match[2]]) {
 			while (true) {
-			  if (match[2] === 'a') noNestedTagIndex = undefined;
+				if (match[2] === 'a') noNestedTagIndex = undefined;
 				if (currentParent.rawTagName === match[2]) {
 					// Update range end for closed tag
 					(<[number, number]>currentParent.range)[1] = createRange(-1, Math.max(lastTextPos, tagEndPos))[1];

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1025,6 +1025,7 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 	let currentParent = root;
 	const stack = [root];
 	let lastTextPos = -1;
+	let noNestedTagIndex: undefined | number = undefined;
 	let match: RegExpExecArray;
 	// https://github.com/taoqf/node-html-parser/issues/38
 	data = `<${frameflag}>${data}</${frameflag}>`;
@@ -1081,10 +1082,14 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 				}
 			}
 
-			if (currentParent.rawTagName === 'a' && match[2] === 'a') {
-				stack.pop();
-				currentParent = arr_back(stack);
-			}
+      // Prevent nested A tags by terminating the last A and starting a new one : see issue #144
+			if (match[2] === 'a') {
+        if (noNestedTagIndex !== undefined) {
+          stack.splice(noNestedTagIndex);
+          currentParent = arr_back(stack);
+        }
+        noNestedTagIndex = stack.length;
+      }
 
 			const tagEndPos = kMarkupPattern.lastIndex;
 			const tagStartPos = tagEndPos - match[0].length;
@@ -1123,6 +1128,7 @@ export function base_parse(data: string, options = { lowerCaseTagName: false, co
 		// Handle closing tags or self-closed elements (ie </tag> or <br>)
 		if (match[1] || match[4] || kSelfClosingElements[match[2]]) {
 			while (true) {
+			  if (match[2] === 'a') noNestedTagIndex = undefined;
 				if (currentParent.rawTagName === match[2]) {
 					// Update range end for closed tag
 					(<[number, number]>currentParent.range)[1] = createRange(-1, Math.max(lastTextPos, tagEndPos))[1];

--- a/test/144.js
+++ b/test/144.js
@@ -1,18 +1,33 @@
-const { parse } = require('../dist');
+const { parse, NodeType } = require('../dist');
 
 describe('issue 144', function () {
 	it('Nested A tags parsed improperly', function () {
-		const html = `<a href="#">link <a href="#">nested link</a> end</a>`;
+		const html = `<a href="#"><b>link <a href="#">nested link</a> end</b></a>`;
+
 		const root = parse(html);
-		root.innerHTML.should.eql(`<a href="#">link </a><a href="#">nested link</a> end`);
+
+		root.innerHTML.should.eql(`<a href="#"><b>link </b></a><a href="#">nested link</a> end`);
 		root.childNodes.length.should.eql(3);
+
 		const a1 = root.childNodes[0];
 		a1.tagName.should.eql('A');
-		a1.nodeType.should.eql(1);
-		const a2 = root.childNodes[1];
-		a2.nodeType.should.eql(1);
-		const t1 = root.childNodes[2];
-		t1.nodeType.should.eql(3);
-		t1.textContent.should.eql(' end');
+		a1.nodeType.should.eql(NodeType.ELEMENT_NODE);
+		a1.childNodes.length.should.eql(1);
+
+		const b = a1.childNodes[0];
+		b.tagName.should.eql('B');
+		b.childNodes.length.should.eql(1);
+		b.text.should.eql('link ');
+
+    const a2 = root.childNodes[1];
+    a2.tagName.should.eql('A');
+    a2.nodeType.should.eql(NodeType.ELEMENT_NODE);
+    a2.childNodes.length.should.eql(1);
+    a2.childNodes[0].nodeType.should.eql(NodeType.TEXT_NODE);
+    a2.text.should.eql('nested link');
+
+		const endText = root.childNodes[2];
+    endText.nodeType.should.eql(NodeType.TEXT_NODE);
+    endText.textContent.should.eql(' end');
 	});
 });

--- a/test/144.js
+++ b/test/144.js
@@ -1,12 +1,13 @@
 const { parse, NodeType } = require('../dist');
 
+// Also see comments on https://github.com/taoqf/node-html-parser/pull/148 for additional issues corrected
 describe('issue 144', function () {
 	it('Nested A tags parsed improperly', function () {
-		const html = `<a href="#"><b>link <a href="#">nested link</a> end</b></a>`;
+		const html = `<A href="#"><b>link <a href="#">nested link</a> end</b></A>`;
 
 		const root = parse(html);
 
-		root.innerHTML.should.eql(`<a href="#"><b>link </b></a><a href="#">nested link</a> end`);
+		root.innerHTML.should.eql(`<A href="#"><b>link </b></A><a href="#">nested link</a> end`);
 		root.childNodes.length.should.eql(3);
 
 		const a1 = root.childNodes[0];

--- a/test/144.js
+++ b/test/144.js
@@ -19,15 +19,15 @@ describe('issue 144', function () {
 		b.childNodes.length.should.eql(1);
 		b.text.should.eql('link ');
 
-    const a2 = root.childNodes[1];
-    a2.tagName.should.eql('A');
-    a2.nodeType.should.eql(NodeType.ELEMENT_NODE);
-    a2.childNodes.length.should.eql(1);
-    a2.childNodes[0].nodeType.should.eql(NodeType.TEXT_NODE);
-    a2.text.should.eql('nested link');
+		const a2 = root.childNodes[1];
+		a2.tagName.should.eql('A');
+		a2.nodeType.should.eql(NodeType.ELEMENT_NODE);
+		a2.childNodes.length.should.eql(1);
+		a2.childNodes[0].nodeType.should.eql(NodeType.TEXT_NODE);
+		a2.text.should.eql('nested link');
 
 		const endText = root.childNodes[2];
-    endText.nodeType.should.eql(NodeType.TEXT_NODE);
-    endText.textContent.should.eql(' end');
+		endText.nodeType.should.eql(NodeType.TEXT_NODE);
+		endText.textContent.should.eql(' end');
 	});
 });


### PR DESCRIPTION
## Related Issues

- #144 
- https://github.com/crosstype/node-html-markdown/issues/25

## Still Failing

- Deeply nested A

   ```html
   <a href="#"><b>link <a href="#">nested link</a> end</b></a>
   ```

- Uppercase A tag name

   ```html
   <A href="#"><b>link <a href="#">nested link</a> end</b></A>
   ```

## Performance Notes

When I said it wouldn't have a perf impact, I should have more correctly stated that the impact would be negligible.

I did a bit of perf testing and found that the added operation: `if (myVar === 'a' || myVar === 'A')` runs at 436,132,968 ops per second. The extra bit of logic inside the conditional will be even less impactful, as it will rarely execute, and is also extremely inexpensive.

In short, I don't expect a noticeable difference for the changes.