### PR TITLE
Ensure ESM support. Fixes #149

### DIFF
--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,3 +1,1 @@
 require: blanket,should,spec
-node-option:
-  - 'experimental-specifier-resolution=node'

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,1 +1,3 @@
 require: blanket,should,spec
+node-option:
+  - 'experimental-specifier-resolution=node'

--- a/package.cjs.json
+++ b/package.cjs.json
@@ -1,0 +1,3 @@
+{
+	"type": "commonjs"
+}

--- a/package.json
+++ b/package.json
@@ -2,19 +2,30 @@
 	"name": "node-html-parser",
 	"version": "4.1.4",
 	"description": "A very fast HTML parser, generating a simplified DOM, with basic element query support.",
-	"main": "dist/index.js",
+	"type": "module",
+	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/esm/index.js",
+			"require": "./dist/cjs/index.js"
+		},
+		"./*": {
+			"import": "./dist/esm/*.js",
+			"require": "./dist/cjs/*.js"
+		}
+	},
+	"types": "dist/types/index.d.ts",
 	"scripts": {
 		"test": "mocha",
 		"lint": "eslint ./src/*.ts ./src/**/*.ts",
 		"clean": "del-cli ./dist/",
-		"ts:cjs": "tsc -m commonjs",
+		"ts:cjs": "tsc -m commonjs --outDir ./dist/cjs/ --declaration true --declarationDir ./dist/types/ && cpy package.cjs.json ./dist/cjs/ --rename=package.json",
 		"ts:amd": "tsc -t es5 -m amd -d false --outFile ./dist/main.js",
 		"ts:esm": "tsc -t es2019 -m esnext -d false --outDir ./dist/esm/",
 		"build": "npm run lint && npm run clean && npm run ts:cjs && npm run ts:amd && npm run ts:esm",
 		"dev": "tsc -w & mocha -w ./test/*.js",
-		"pretest": "tsc -m commonjs",
+		"pretest": "npm run ts:cjs",
 		"release": "yarn build && np",
 		"prepare": "npm run build"
 	},
@@ -45,6 +56,7 @@
 		"@typescript-eslint/parser": "latest",
 		"blanket": "latest",
 		"cheerio": "^1.0.0-rc.5",
+		"cpy-cli": "^3.1.1",
 		"del-cli": "latest",
 		"eslint": "latest",
 		"eslint-config-prettier": "latest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-export { default as CommentNode } from './nodes/comment';
-export { default as HTMLElement, Options } from './nodes/html';
-export { default as parse, default } from './parse';
-export { default as valid } from './valid';
-export { default as Node } from './nodes/node';
-export { default as TextNode } from './nodes/text';
-export { default as NodeType } from './nodes/type';
+export { default as CommentNode } from './nodes/comment.js';
+export { default as HTMLElement, Options } from './nodes/html.js';
+export { default as parse, default } from './parse.js';
+export { default as valid } from './valid.js';
+export { default as Node } from './nodes/node.js';
+export { default as TextNode } from './nodes/text.js';
+export { default as NodeType } from './nodes/type.js';

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,7 +1,7 @@
 import { Adapter/*, Predicate*/ } from 'css-select/lib/types';
-import HTMLElement from './nodes/html';
-import Node from './nodes/node';
-import NodeType from './nodes/type';
+import HTMLElement from './nodes/html.js';
+import Node from './nodes/node.js';
+import NodeType from './nodes/type.js';
 
 export declare type Predicate = (node: Node) => node is HTMLElement;
 

--- a/src/nodes/comment.ts
+++ b/src/nodes/comment.ts
@@ -1,6 +1,6 @@
-import Node from './node';
-import NodeType from './type';
-import HTMLElement from './html';
+import Node from './node.js';
+import NodeType from './type.js';
+import HTMLElement from './html.js';
 
 export default class CommentNode extends Node {
 	public constructor(public rawText: string, parentNode: HTMLElement, range?: [ number, number ]) {

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1,11 +1,11 @@
 import he from 'he';
 import { selectAll, selectOne } from 'css-select';
-import Node from './node';
-import NodeType from './type';
-import TextNode from './text';
-import Matcher from '../matcher';
-import arr_back from '../back';
-import CommentNode from './comment';
+import Node from './node.js';
+import NodeType from './type.js';
+import TextNode from './text.js';
+import Matcher from '../matcher.js';
+import arr_back from '../back.js';
+import CommentNode from './comment.js';
 
 // const { decode } = he;
 

--- a/src/nodes/node.ts
+++ b/src/nodes/node.ts
@@ -1,4 +1,4 @@
-import { decode, encode } from 'he';
+import he from 'he';
 import NodeType from './type';
 import HTMLElement from './html';
 
@@ -28,9 +28,9 @@ export default abstract class Node {
 		return this.rawText;
 	}
 	public get textContent() {
-		return decode(this.rawText);
+		return he.decode(this.rawText);
 	}
 	public set textContent(val: string) {
-		this.rawText = encode(val);
+		this.rawText = he.encode(val);
 	}
 }

--- a/src/nodes/node.ts
+++ b/src/nodes/node.ts
@@ -1,6 +1,6 @@
 import he from 'he';
-import NodeType from './type';
-import HTMLElement from './html';
+import NodeType from './type.js';
+import HTMLElement from './html.js';
 
 /**
  * Node Class as base class for TextNode and HTMLElement.

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -1,4 +1,4 @@
-import { decode } from 'he';
+import he from 'he';
 import HTMLElement from './html';
 import Node from './node';
 import NodeType from './type';
@@ -59,7 +59,7 @@ export default class TextNode extends Node {
 	 * @return {string} text content
 	 */
 	public get text() {
-		return decode(this.rawText);
+		return he.decode(this.rawText);
 	}
 
 	/**

--- a/src/nodes/text.ts
+++ b/src/nodes/text.ts
@@ -1,7 +1,7 @@
 import he from 'he';
-import HTMLElement from './html';
-import Node from './node';
-import NodeType from './type';
+import HTMLElement from './html.js';
+import Node from './node.js';
+import NodeType from './type.js';
 
 /**
  * TextNode to contain a text element in DOM tree.

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,1 +1,1 @@
-export { parse as default } from './nodes/html';
+export { parse as default } from './nodes/html.js';

--- a/src/valid.ts
+++ b/src/valid.ts
@@ -1,4 +1,4 @@
-import { base_parse, Options } from './nodes/html';
+import { base_parse, Options } from './nodes/html.js';
 
 /**
  * Parses HTML and returns a root element

--- a/test/100.js
+++ b/test/100.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('#querySelectorAll', function () {
 	it('nothing mached', function () {

--- a/test/100.js
+++ b/test/100.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('#querySelectorAll', function () {
 	it('nothing mached', function () {

--- a/test/106.js
+++ b/test/106.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 const fs = require('fs');
 
 describe.skip('Memory leak', function () {

--- a/test/106.js
+++ b/test/106.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 const fs = require('fs');
 
 describe.skip('Memory leak', function () {

--- a/test/109.js
+++ b/test/109.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('self-close tag', function () {
 	it('should not teat textarea as self-colse tag', async function () {

--- a/test/109.js
+++ b/test/109.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('self-close tag', function () {
 	it('should not teat textarea as self-colse tag', async function () {

--- a/test/112.js
+++ b/test/112.js
@@ -1,4 +1,4 @@
-const { parse, HTMLElement } = require('../dist');
+const { parse, HTMLElement } = require('..');
 
 // https://github.com/taoqf/node-html-parser/pull/112
 describe('pull/112', function () {

--- a/test/112.js
+++ b/test/112.js
@@ -1,4 +1,4 @@
-const { parse, HTMLElement } = require('..');
+const { parse, HTMLElement } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/pull/112
 describe('pull/112', function () {

--- a/test/115.js
+++ b/test/115.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('issue 115', function () {
 	it('parse html', async function () {

--- a/test/115.js
+++ b/test/115.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('issue 115', function () {
 	it('parse html', async function () {

--- a/test/119.js
+++ b/test/119.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/pull/112
 describe('issue 119 closest', function () {

--- a/test/119.js
+++ b/test/119.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/pull/112
 describe('issue 119 closest', function () {

--- a/test/135.js
+++ b/test/135.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('pr 135', function () {
 	it('shoud not decode text', function () {

--- a/test/135.js
+++ b/test/135.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('pr 135', function () {
 	it('shoud not decode text', function () {

--- a/test/144.js
+++ b/test/144.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('issue 144', function () {
 	it('Nested A tags parsed improperly', function () {

--- a/test/144.js
+++ b/test/144.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('issue 144', function () {
 	it('Nested A tags parsed improperly', function () {

--- a/test/145.js
+++ b/test/145.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('issue 145', function () {
 	it('shoud parse attributes right', function () {

--- a/test/145.js
+++ b/test/145.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('issue 145', function () {
 	it('shoud parse attributes right', function () {

--- a/test/28,59,74.js
+++ b/test/28,59,74.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('issues/28', function () {
 	it('query with dl > dt', function () {

--- a/test/28,59,74.js
+++ b/test/28,59,74.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('issues/28', function () {
 	it('query with dl > dt', function () {

--- a/test/41.js
+++ b/test/41.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/41
 describe('#exchangeChild()', function () {

--- a/test/41.js
+++ b/test/41.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/41
 describe('#exchangeChild()', function () {

--- a/test/42.js
+++ b/test/42.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('issue 42', function () {
 	it('svg attribute', function () {

--- a/test/42.js
+++ b/test/42.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('issue 42', function () {
 	it('svg attribute', function () {

--- a/test/48.js
+++ b/test/48.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('issue 48', function () {
 	it('get decoded text', function () {

--- a/test/48.js
+++ b/test/48.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('issue 48', function () {
 	it('get decoded text', function () {

--- a/test/51.js
+++ b/test/51.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe.skip('issue 51', function () {
 	it('vue: > in attibute value', function () {

--- a/test/51.js
+++ b/test/51.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe.skip('issue 51', function () {
 	it('vue: > in attibute value', function () {

--- a/test/69.js
+++ b/test/69.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/69
 describe('issues/69', function () {

--- a/test/69.js
+++ b/test/69.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/69
 describe('issues/69', function () {

--- a/test/70.js
+++ b/test/70.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/70
 describe('issues/70', function () {

--- a/test/70.js
+++ b/test/70.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/70
 describe('issues/70', function () {

--- a/test/84.js
+++ b/test/84.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/84
 describe('#querySelector()', function () {

--- a/test/84.js
+++ b/test/84.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/84
 describe('#querySelector()', function () {

--- a/test/85.js
+++ b/test/85.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/85
 describe('#remove()', function () {

--- a/test/85.js
+++ b/test/85.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/85
 describe('#remove()', function () {

--- a/test/95.js
+++ b/test/95.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/95
 describe('#textContent', function () {

--- a/test/95.js
+++ b/test/95.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/95
 describe('#textContent', function () {

--- a/test/98.js
+++ b/test/98.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/98
 describe('getAttribute should be case insensitive', function () {

--- a/test/98.js
+++ b/test/98.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/98
 describe('getAttribute should be case insensitive', function () {

--- a/test/caseinsensitive.js
+++ b/test/caseinsensitive.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/75
 describe('query should be case insensitive', function () {

--- a/test/caseinsensitive.js
+++ b/test/caseinsensitive.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/75
 describe('query should be case insensitive', function () {

--- a/test/compare-node-html-parser.mjs
+++ b/test/compare-node-html-parser.mjs
@@ -1,5 +1,5 @@
 import benchmark from 'htmlparser-benchmark';
-import node_html_parser from '../dist/index.js';
+import node_html_parser from '..';
 
 // const { parse } = node_html_parser;
 

--- a/test/compare-node-html-parser.mjs
+++ b/test/compare-node-html-parser.mjs
@@ -1,11 +1,10 @@
 import benchmark from 'htmlparser-benchmark';
-import node_html_parser from '..';
+import { parse } from '../dist/esm/index.js';
 
 // const { parse } = node_html_parser;
 
 var bench = benchmark(function (html, callback) {
-	// parse(html);
-	node_html_parser.parse(html);
+	parse(html);
 	callback();
 });
 

--- a/test/emptyattribute.js
+++ b/test/emptyattribute.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/95
 describe('empty attribute', function () {

--- a/test/emptyattribute.js
+++ b/test/emptyattribute.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/95
 describe('empty attribute', function () {

--- a/test/html.js
+++ b/test/html.js
@@ -1,10 +1,8 @@
 const should = require('should');
 const fs = require('fs');
 
-const HTMLParser = require('../dist');
-const HTMLElement = require('../dist/nodes/html').default;
-const TextNode = require('../dist/nodes/text').default;
-const CommentNode = require('../dist/nodes/comment').default;
+const HTMLParser = require('..');
+const { HTMLElement, TextNode, CommentNode } = HTMLParser;
 
 describe('HTML Parser', function () {
 	const parseHTML = HTMLParser.parse;

--- a/test/html.js
+++ b/test/html.js
@@ -1,7 +1,7 @@
 const should = require('should');
 const fs = require('fs');
 
-const HTMLParser = require('..');
+const HTMLParser = require('../dist/cjs/index.js');
 const { HTMLElement, TextNode, CommentNode } = HTMLParser;
 
 describe('HTML Parser', function () {

--- a/test/node-ranges.js
+++ b/test/node-ranges.js
@@ -1,4 +1,4 @@
-const { parse, HTMLElement, TextNode, CommentNode } = require('..');
+const { parse, HTMLElement, TextNode, CommentNode } = require('../dist/cjs/index.js');
 const hp2 = require('htmlparser2')
 const mochaEach = require('mocha-each');
 

--- a/test/node-ranges.js
+++ b/test/node-ranges.js
@@ -1,4 +1,4 @@
-const { parse, HTMLElement, TextNode, CommentNode } = require('../dist');
+const { parse, HTMLElement, TextNode, CommentNode } = require('..');
 const hp2 = require('htmlparser2')
 const mochaEach = require('mocha-each');
 

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "commonjs"
+}

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/38
 describe('HTML Parser', function () {

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/38
 describe('HTML Parser', function () {

--- a/test/pre.js
+++ b/test/pre.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/77
 describe('pre tag', function () {

--- a/test/pre.js
+++ b/test/pre.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/77
 describe('pre tag', function () {

--- a/test/quoteattributes.js
+++ b/test/quoteattributes.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 // https://github.com/taoqf/node-html-parser/issues/62
 describe('quote attributes', function () {

--- a/test/quoteattributes.js
+++ b/test/quoteattributes.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 // https://github.com/taoqf/node-html-parser/issues/62
 describe('quote attributes', function () {

--- a/test/replacewith.js
+++ b/test/replacewith.js
@@ -1,4 +1,4 @@
-const { parse } = require('..');
+const { parse } = require('../dist/cjs/index.js');
 
 describe('should parse tag correct', function () {
 	it('should get attribute with :', function () {

--- a/test/replacewith.js
+++ b/test/replacewith.js
@@ -1,4 +1,4 @@
-const { parse } = require('../dist');
+const { parse } = require('..');
 
 describe('should parse tag correct', function () {
 	it('should get attribute with :', function () {

--- a/test/valid.js
+++ b/test/valid.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const { valid, parse } = require('..');
+const { valid, parse } = require('../dist/cjs/index.js');
 
 describe('parseWithValidation', function () {
 	// parse with validation tests

--- a/test/valid.js
+++ b/test/valid.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-const { valid, parse } = require('../dist');
+const { valid, parse } = require('..');
 
 describe('parseWithValidation', function () {
 	// parse with validation tests


### PR DESCRIPTION
Fixes #149.

Tests included are passed okay (after fixing paths and adding `experimental-specifier-resolution=node`). I noticed the benchmarks on the README are "a bit" outdated, but it isn't my concern today.

### Why currently included tests were passing despite they were using ES modules?

There seems to be files in `test` folder using ES modules, among them `compare-node-html-parser.mjs`.

Despite first impression, **it wasn't using ES modules version** from `./dist/esm/*`, but it was using `./dist/index.js`; that's why the benchmark was running fine before.

### Additional testing

I tested proper the ESM support myself using simple project like:

`package.json`
```json
{
	"type": "module",
	"scripts": {
		"start": "node --experimental-specifier-resolution=node main.js"
	}
}
```
_(changing type to `commonjs` (when not added at all, it's also `commonjs`))_

`main.js`
```js
import { parse } from "node-html-parser";
// const { parse } = require("node-html-parser");
console.log(parse); // [Function: parse]
```
_(I had the `node-html-parser` linked by `npm link` for the test)_

Results: 
* before this PR it fails on (ES) module/`import` approach, it works only using `require` (commonjs).
* after this PR it works both ways.

### Notes

* `experimental-specifier-resolution=node` is used because generated files in `esm` version don't have `.js`/`.mjs` extensions. It could be done by adding `.js` extension in Typescript sources (yes, in `.ts` adding `.js` when importing), but it was more work and I wasn't sure should I really edit sources for it. The choice itself don't have to be final, and even node devs still don't know what they want to finally do with the directory name resolution in ES modules.
