### PR TITLE
fix: support esbuild

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -1,11 +1,3 @@
-import nhp from '../dist/index.js'
+export { default } from '../dist/index.js'
+export * from '../dist/index.js'
 
-export const CommentNode = nhp.CommentNode;
-export const HTMLElement = nhp.HTMLElement;
-export const parse = nhp.parse;
-export const valid = nhp.valid;
-export const Node = nhp.Node;
-export const TextNode = nhp.TextNode;
-export const NodeType = nhp.NodeType;
-
-export default nhp;

--- a/esm/index.js
+++ b/esm/index.js
@@ -1,2 +1,11 @@
-export { default } from '../dist/index.js'
-export { CommentNode, HTMLElement, parse, valid, Node, TextNode, NodeType } from '../dist/index.js'
+import nhp from '../dist/index.js'
+
+export const CommentNode = nhp.CommentNode;
+export const HTMLElement = nhp.HTMLElement;
+export const parse = nhp.parse;
+export const valid = nhp.valid;
+export const Node = nhp.Node;
+export const TextNode = nhp.TextNode;
+export const NodeType = nhp.NodeType;
+
+export default nhp;

--- a/esm/index.js
+++ b/esm/index.js
@@ -1,3 +1,2 @@
 export { default } from '../dist/index.js'
-export * from '../dist/index.js'
-
+export { CommentNode, HTMLElement, parse, valid, Node, TextNode, NodeType } from '../dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,18 @@
 export { default as CommentNode } from './nodes/comment';
 export { default as HTMLElement, Options } from './nodes/html';
-export { default as parse, default } from './parse';
+export { default as parse } from './parse';
 export { default as valid } from './valid';
 export { default as Node } from './nodes/node';
 export { default as TextNode } from './nodes/text';
 export { default as NodeType } from './nodes/type';
+
+Object.assign(parse, {
+  CommentNode,
+  HTMLElement,
+  Options,
+  parse,
+  valid,
+  Node,
+  TextNode,
+  NodeType,
+});


### PR DESCRIPTION
fix the following bug
```shell
npm i esbuild node-html-parser typescript
echo 'import { parse, HTMLElement } from "node-html-parser";console.log({ parse, HTMLElement });' > test.ts
npx esbuild test.ts --bundle --outfile=test.js
node test.js
```
will be output `{ parse:undefined, HTMLElement:undefined }`