### PR TITLE
Update benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,19 @@ npm install --save node-html-parser
 
 Faster than htmlparser2!
 
-```shell
-htmlparser      :26.7111 ms/file ± 170.066
-cheerio         :24.2480 ms/file ± 17.1711
-parse5          :13.7239 ms/file ± 8.68561
-high5           :7.75466 ms/file ± 5.33549
-htmlparser2     :5.27376 ms/file ± 8.68456
-node-html-parser:2.85768 ms/file ± 2.87784
+```shellhtmlparser2        : 2.63714 ms/file ± 4.30057
+html5parser        : 2.84375 ms/file ± 3.54394
+neutron-html5parser: 3.04575 ms/file ± 1.89848
+node-html-parser   : 3.10731 ms/file ± 2.12570
+htmlparser2-dom    : 3.61990 ms/file ± 4.81977
+html-dom-parser    : 4.54985 ms/file ± 5.66466
+libxmljs           : 5.00315 ms/file ± 3.79862
+htmljs-parser      : 6.95162 ms/file ± 8.35213
+parse5             : 11.3511 ms/file ± 8.44549
+htmlparser         : 18.9205 ms/file ± 113.063
+html-parser        : 33.7231 ms/file ± 26.3528
+saxes              : 67.8214 ms/file ± 191.603
+html5              : 145.636 ms/file ± 187.847
 ```
 
 Tested with [htmlparser-benchmark](https://github.com/AndreasMadsen/htmlparser-benchmark).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ npm install --save node-html-parser
 
 ## Performance
 
-```shellhtmlparser2        : 2.63714 ms/file ± 4.30057
+```shell
+htmlparser2        : 2.63714 ms/file ± 4.30057
 html5parser        : 2.84375 ms/file ± 3.54394
 neutron-html5parser: 3.04575 ms/file ± 1.89848
 node-html-parser   : 3.10731 ms/file ± 2.12570

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ npm install --save node-html-parser
 
 ## Performance
 
-Faster than htmlparser2!
-
 ```shellhtmlparser2        : 2.63714 ms/file ± 4.30057
 html5parser        : 2.84375 ms/file ± 3.54394
 neutron-html5parser: 3.04575 ms/file ± 1.89848


### PR DESCRIPTION
Hi everyone!

Very cool project, keep up the good work! You really upped the game with producing a fast HTML parser, and motivated me to work on `htmlparser2` again.

I just saw the benchmark in the README, and saw that `htmlparser2` was directly mentioned (happy to see!). I had a big push to speed up `htmlparser2` several months ago, and things look a bit different now; results can be seen at https://github.com/AndreasMadsen/htmlparser-benchmark/blob/master/stats.txt

Not sure if you want to include the benchmark in the first place, linking to the current results might be the better approach.

Let me know what you think!