### PR TITLE
Fix non-default ESM imports

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -1,4 +1,5 @@
-import nhp from '../dist/index.js'
+import nhp_default from '../dist/index.js'
+import * as nhp from '../dist/index.js'
 
 export const CommentNode = nhp.CommentNode;
 export const HTMLElement = nhp.HTMLElement;
@@ -8,4 +9,4 @@ export const Node = nhp.Node;
 export const TextNode = nhp.TextNode;
 export const NodeType = nhp.NodeType;
 
-export default nhp;
+export default nhp_default;


### PR DESCRIPTION
`esm/index.js` currently does:

```
import nhp from '../dist/index.js'
```

This is importing the default export from `../dist/index.js` AKA `src/index.ts`, which is the `parse` function:

```
export { default as parse, default } from './parse';
                           ^^^^^^^
```

... which means when `esm/index.js` later tries to do this:

```
export const CommentNode = nhp.CommentNode;
```

... `nhp` is actually the `parse` function, which means `nhp.CommentNode` is undefined.