### PR TITLE
feat: void tag closing slash and space

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ Parse the data provided, and return the root of the generated DOM.
   ```js
   {
     lowerCaseTagName: false,  // convert tag name to lower case (hurts performance heavily)
-    comment: false,            // retrieve comments (hurts performance slightly)
+    comment: false,           // retrieve comments (hurts performance slightly)
+    voidTag: {  
+      closingSlash: true,     // void tag serialisation, add a final slash <br/>
+      closingSpace : 'always' // space before the final slash : 'never', 'always', 'attrPresent'
+                              // with attrPresent; <br/>, <meta charset="UTF-8" />
+    },
     blockTextElements: {
       script: true,	// keep text content when parsing
       noscript: true,	// keep text content when parsing


### PR DESCRIPTION
Hi,

I have added two options to format the serialization of void tags (e.g. `br`, `link`), the use case was comparing two states of a HTML document, before and after DOM transformations, it was generating noise in the diff.

The configuration can be set with environment variables :

```
export HTML_VOID_TAG_CLOSING_SLASH=1
export HTML_VOID_TAG_CLOSING_SPACE='always'
```

Then options if present will override them each time `parse` is called:

```js
{
  voidTag: {
      closingSlash: true,     // void tag serialisation, add a final slash <br/>
      closingSpace : 'always' // space before the final slash : 'never', 'always', 'attrPresent'
  }                           // with attrPresent; <br/>, <meta charset="UTF-8" />
}
```

I don’t like to use global variables to set contextual data, but I cannot find an easy way to pass the options when doing serialisation. It should be propagated from the root element, or passed and dispatched when calling `toString`.
