### PR TITLE
fix: fix vite build error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,7 @@
 		"no-caller": "error",
 		"no-debugger": "warn",
 		"no-dupe-class-members": "off",
-		"no-duplicate-imports": "error",
+		"no-duplicate-imports": "off",
 		"no-else-return": "warn",
 		"no-empty": [
 			"warn",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,33 @@
-export { default as CommentNode } from './nodes/comment';
-export { default as HTMLElement, Options } from './nodes/html';
-export { default as parse, default } from './parse';
-export { default as valid } from './valid';
-export { default as Node } from './nodes/node';
-export { default as TextNode } from './nodes/text';
-export { default as NodeType } from './nodes/type';
+import { default as CommentNode } from './nodes/comment';
+import { default as HTMLElement } from './nodes/html';
+import type { Options } from './nodes/html';
+import { default as parse } from './parse';
+import { default as valid } from './valid';
+import { default as Node } from './nodes/node';
+import { default as TextNode } from './nodes/text';
+import { default as NodeType } from './nodes/type';
+
+export default {
+  CommentNode,
+  HTMLElement,
+  parse,
+  valid,
+  Node,
+  TextNode,
+  NodeType,
+};
+
+export {
+  CommentNode,
+  HTMLElement,
+  parse,
+  valid,
+  Node,
+  TextNode,
+  NodeType,
+};
+
+export type {
+  Options,
+};
+


### PR DESCRIPTION
fix build error when use vite build:


```js
import { parse } from 'node-html-parser'

// parse is not a function
parse(text);
```