### PR TITLE
Added support for shorthand event handler syntax

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -687,7 +687,7 @@ export default class HTMLElement extends Node {
 		}
 		const attrs = {} as RawAttributes;
 		if (this.rawAttrs) {
-			const re = /([a-zA-Z()[\]#][a-zA-Z0-9-_:()[\]#]*)(?:\s*=\s*((?:'[^']*')|(?:"[^"]*")|\S+))?/g;
+			const re = /([a-zA-Z()[\]#@][a-zA-Z0-9-_:()[\]#]*)(?:\s*=\s*((?:'[^']*')|(?:"[^"]*")|\S+))?/g;
 			let match: RegExpExecArray;
 			while ((match = re.exec(this.rawAttrs))) {
 				const key = match[1];

--- a/test/tests/html.js
+++ b/test/tests/html.js
@@ -214,11 +214,12 @@ describe('HTML Parser', function () {
 
 		describe('#rawAttributes', function () {
 			it('should return escaped attributes of the element', function () {
-				const root = parseHTML('<p a=12 data-id="!$$&amp;" yAz=\'1\'></p>');
+				const root = parseHTML('<p a=12 data-id="!$$&amp;" yAz=\'1\' @click="doSmt()"></p>');
 				root.firstChild.rawAttributes.should.eql({
 					'a': '12',
 					'data-id': '!$$&amp;',
-					'yAz': '1'
+					'yAz': '1',
+					'@click': 'doSmt()'
 				});
 			});
 		});


### PR DESCRIPTION
The HTML attribute regex does not capture attributes that start with an `@` correctly. You might run into this when working with shorthand event handlers in micro-frameworks such as Alpine.js or petite-vue. This fixes that.

e.g. `@click="doSmt()"` yields attribute `click` with a value of `doSmt()`. With the current regex, `rawAttrs` does not contain the right value (it contains `click` without the `@`). This PR fixes that.

https://github.com/taoqf/node-html-parser/blob/05f474f751a93ea30590733380263d2f669a3987/src/nodes/html.ts#L690 