### PR TITLE
Chore: Update the return of the closest function

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -616,7 +616,7 @@ export default class HTMLElement extends Node {
 				},
 			});
 			if (e) {
-				return e;
+				return e as HTMLElement;
 			}
 			el = el.parentNode;
 		}


### PR DESCRIPTION
Update the return of the closest function to ensure that we return either a HTMLElement or null. 

As the MDN spec for the .closest function states, the return type is _'The closest ancestor Element or itself, which matches the selectors. If there are no such element, null'_ 

This means it should be an actual Element type and not a node. This solves a wider issue with TS that prevents users from chaining `querySelector` and calls to `closest`.

This provides a much more native behaviour akin to what is actually experienced within the browser environment.