### PR TITLE
First attribute in a tag wins

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -696,7 +696,7 @@ export default class HTMLElement extends Node {
 				const key = match[1];
 				let val = match[2] || null;
 				if (val && (val[0] === `'` || val[0] === `"`)) val = val.slice(1, val.length - 1);
-				attrs[key] = val;
+				attrs[key] = attrs[key] || val;
 			}
 		}
 		this._rawAttrs = attrs;

--- a/test/tests/html.js
+++ b/test/tests/html.js
@@ -333,6 +333,11 @@ describe('HTML Parser', function () {
 				root.firstChild.getAttribute('a').should.eql('a1b');
 			});
 
+			it('should return value of the first attribute', function () {
+				const root = parseHTML('<p a="a1b" a="fail"></p>');
+				root.firstChild.getAttribute('a').should.eql('a1b');
+			});
+
 			it('should return null when there is no such attribute', function () {
 				const root = parseHTML('<p></p>');
 				should.equal(root.firstChild.getAttribute('b'), null);

--- a/test/tests/issues/224.js
+++ b/test/tests/issues/224.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const { parse } = require('@test/test-target');
 
-describe.only('issue 224', function () {
+describe('issue 224', function () {
 	it('query', function () {
 		const html = fs.readFileSync(__dirname + '/../../assets/html/melon.html', 'utf-8');
 		const root = parse(html);


### PR DESCRIPTION
The HTML specification nominally does not allow duplicate attributes in a tag (see [13.1.2.3](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2), last paragraph). However, browsers fail graciously when encountering such a tag, respecting only the first tag present and discarding subsequent duplicates (Safari 17614.1.25.9.10, Chrome 109.0.5414.119).

Bring node-html-parser in alignment with that convention, respecting the first attribute and ignoring subsequent matches.