### PR TITLE
fix: Fixed typo in JSDoc for HTMLElement `structure` method

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -407,7 +407,7 @@ export default class HTMLElement extends Node {
 	}
 	/**
 	 * Get DOM structure
-	 * @return {string} strucutre
+	 * @return {string} structure
 	 */
 	public get structure() {
 		const res = [] as string[];


### PR DESCRIPTION
Happy for this to just be a `docs` commit instead if you'd rather not release this change on its own.