### PR TITLE
restore the prepare script "npm run build"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"test:target": "mocha --recursive \"./test/tests\"",
 		"test:ci": "cross-env TEST_TARGET=dist yarn run test:target",
 		"posttest": "yarn run benchmark",
-		"prepare": "cd test && yarn install",
+		"prepare": "npm run build",
 		"release": "standard-version && git push --follow-tags origin main"
 	},
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"reset": "yarn run clean:global && yarn install && yarn build",
 		"--------------- ": "",
 		"test:target": "mocha --recursive \"./test/tests\"",
-		"test:ci": "cross-env TEST_TARGET=dist yarn run test:target",
+		"test:ci": "cd test && yarn install && cd .. && cross-env TEST_TARGET=dist yarn run test:target",
 		"posttest": "yarn run benchmark",
 		"prepare": "npm run build",
 		"release": "standard-version && git push --follow-tags origin main"


### PR DESCRIPTION
this was originally added in 366d048efddc30ec8411f7624841a596aaa8798d (#125)
and removed in 3140baa26f51bea030ea6679e6eeb038565c443e (#161)

the purpose of the `npm run build` prepare script
is to allow "install from git" which is currently broken

`cd test && yarn install` is not needed for "install from git"

tested with

```
pnpm i 'github:taoqf/node-html-parser#cd3fcd7ba3081c7b546351a282de04596fab502c'
```
