### PR TITLE
fix: #254

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -249,7 +249,7 @@ export default class HTMLElement extends Node {
 	 */
 	public get rawText() {
 		// https://github.com/taoqf/node-html-parser/issues/249
-		if (/br/i.test(this.rawTagName)) {
+		if (/^br$/i.test(this.rawTagName)) {
 			return '\n';
 		}
 		return this.childNodes.reduce((pre, cur) => {

--- a/test/tests/issues/254.js
+++ b/test/tests/issues/254.js
@@ -1,0 +1,10 @@
+const { parse } = require('@test/test-target');
+
+describe('issue 254', function () {
+	it('abbr in innertext should not turn into \\n', function () {
+		const html = `<div>Hello <abbr>World</abbr></div>`;
+		const root = parse(html);
+		const div = root.querySelector('div');
+		div.innerText.should.eql(`Hello World`);
+	});
+});


### PR DESCRIPTION
The `abbr` tag was wrongfully interpreted like the `br` one for `innerText` due to a regex error.

Fixes #254 