### PR TITLE
docs(readme): add missing parse options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,17 @@ Parse the data provided, and return the root of the generated DOM.
 
   ```js
   {
-    lowerCaseTagName: false,  // convert tag name to lower case (hurts performance heavily)
-    comment: false,            // retrieve comments (hurts performance slightly)
-    voidTag:{
+    lowerCaseTagName: false,		// convert tag name to lower case (hurts performance heavily)
+    comment: false,           		// retrieve comments (hurts performance slightly)
+    fixNestedATags: false,    		// fix invalid nested <a> HTML tags 
+    parseNoneClosedTags: false, 	// close none closed HTML tags instead of removing them 
+    voidTag: {
       tags: ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'],	// optional and case insensitive, default value is ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr']
-      closingSlash: true     // optional, default false. void tag serialisation, add a final slash <br/>
+      closingSlash: true	// optional, default false. void tag serialisation, add a final slash <br/>
     },
     blockTextElements: {
-      script: true,	// keep text content when parsing
-      noscript: true,	// keep text content when parsing
+      script: true,		// keep text content when parsing
+      noscript: true,		// keep text content when parsing
       style: true,		// keep text content when parsing
       pre: true			// keep text content when parsing
     }


### PR DESCRIPTION
Two parsing options are missing. That commit adds them to the README file.