### PR TITLE
Implement more getters and methods on HTMLElement, in accordance with the DOM spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Node --|> TextNode
 Node ..> ClassList
 ```
 
+
 ## HTMLElement Methods
 
 ### trimRight()
@@ -216,9 +217,26 @@ Note: Use * for all elements.
 
 Query closest element by css selector. `null` if not found.
 
+### before(...nodesOrStrings)
+
+Insert one or multiple nodes or text before the current element. Does not work on root.
+
+### after(...nodesOrStrings)
+
+Insert one or multiple nodes or text after the current element. Does not work on root.
+
+### prepend(...nodesOrStrings)
+
+Insert one or multiple nodes or text to the first position of an element's child nodes.
+
+### append(...nodesOrStrings)
+
+Insert one or multiple nodes or text to the last position of an element's child nodes.
+This is similar to appendChild, but accepts arbitrarily many nodes and converts strings to text nodes.
+
 ### appendChild(node)
 
-Append a child node to childNodes
+Append a node to an element's child nodes.
 
 ### insertAdjacentHTML(where, html)
 
@@ -298,6 +316,7 @@ Clone a node.
 
 Get element by it's ID.
 
+
 ## HTMLElement Properties
 
 ### text
@@ -312,7 +331,7 @@ Get escaped (as-is) text value of current node and its children. May have
 
 ### tagName
 
-Get or Set tag name of HTMLElement. Notice: the returned value would be an uppercase string.
+Get or Set tag name of HTMLElement. Note that the returned value is an uppercase string.
 
 ### structuredText
 
@@ -322,13 +341,33 @@ Get structured Text.
 
 Get DOM structure.
 
+### childNodes
+
+Get all child nodes. A child node can be a TextNode, a CommentNode and a HTMLElement.
+
+### children
+
+Get all child elements, so all child nodes of type HTMLELement.
+
 ### firstChild
 
-Get first child node. `undefined` if no child.
+Get first child node. `undefined` if the node has no children.
 
 ### lastChild
 
-Get last child node. `undefined` if no child
+Get last child node. `undefined` if the node has no children.
+
+### firstElementChild
+
+Get the first child of type HTMLElement. `undefined` if none exists.
+
+### lastElementChild
+
+Get the first child of type HTMLElement. `undefined` if none exists.
+
+### childElementCount
+
+Get the number of children that are of type HTMLElement.
 
 ### innerHTML
 

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -649,22 +649,6 @@ export default class HTMLElement extends Node {
 	}
 
 	/**
-	 * Get first child node
-	 * @return {Node | undefined} first child node; or undefined if none
-	 */
-	public get firstChild(): Node | undefined {
-		return this.childNodes[0];
-	}
-
-	/**
-	 * Get last child node
-	 * @return {Node | undefined} last child node; or undefined if none
-	 */
-	public get lastChild(): Node | undefined {
-		return arr_back(this.childNodes);
-	}
-
-	/**
 	 * Get attributes
 	 * @access private
 	 * @return {Object} parsed and unescaped attributes
@@ -829,9 +813,6 @@ export default class HTMLElement extends Node {
 			);
 		}
 		return this;
-		// if (!where || html === undefined || html === null) {
-		// 	return;
-		// }
 	}
 
 	/** Prepend nodes or strings to this node's children. */
@@ -934,12 +915,36 @@ export default class HTMLElement extends Node {
 		return children;
 	}
 
+	/**
+	 * Get the first child node.
+	 * @return The first child or undefined if none exists.
+	 */
+	public get firstChild(): Node | undefined {
+		return this.childNodes[0];
+	}
+	/**
+	 * Get the first child node of type {@link HTMLElement}.
+	 * @return The first child element or undefined if none exists.
+	 */
 	public get firstElementChild(): HTMLElement | undefined {
 		return this.children[0];
 	}
+
+	/**
+	 * Get the last child node.
+	 * @return The last child or undefined if none exists.
+	 */
+	public get lastChild(): Node | undefined {
+		return arr_back(this.childNodes);
+	}
+	/**
+	 * Get the last child node of type {@link HTMLElement}.
+	 * @return The last child element or undefined if none exists.
+	 */
 	public get lastElementChild(): HTMLElement | undefined {
 		return this.children[this.children.length - 1];
 	}
+
 	public get childElementCount(): number {
 		return this.children.length;
 	}
@@ -948,9 +953,7 @@ export default class HTMLElement extends Node {
 		return this.classList.toString();
 	}
 
-	/**
-	 * Clone this Node
-	 */
+	/** Clone this Node */
 	public clone() {
 		return parse(this.toString(), this._parseOptions).firstChild;
 	}
@@ -1247,10 +1250,9 @@ function resolveInsertable(insertable: NodeInsertable[]): Node[] {
 	return insertable.map(val => {
 		if (typeof val === 'string') {
 			return new TextNode(val);
-		} else {
-			val.remove();
-			return val;
 		}
+		val.remove();
+		return val;
 	});
 }
 

--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -909,6 +909,27 @@ export default class HTMLElement extends Node {
 		}
 	}
 
+	/** Get all childNodes of type {@link HTMLElement}. */
+	public get children(): HTMLElement[] {
+		const children = [];
+		for (const childNode of this.childNodes) {
+			if (childNode instanceof HTMLElement) {
+				children.push(childNode);
+			}
+		}
+		return children;
+	}
+
+	public get firstElementChild(): HTMLElement | undefined {
+		return this.children[0];
+	}
+	public get lastElementChild(): HTMLElement | undefined {
+		return this.children[this.children.length - 1];
+	}
+	public get childElementCount(): number {
+		return this.children.length;
+	}
+
 	public get classNames() {
 		return this.classList.toString();
 	}

--- a/test/tests/html.js
+++ b/test/tests/html.js
@@ -580,8 +580,92 @@ describe('HTML Parser', function () {
 			});
 		});
 
+		describe('Base insertion operations', () => {
+			describe('#before', () => {
+				it('Should insert multiple nodes in order', () => {
+					const root = parseHTML(`<section><div></div></section>`);
+					root.children[0].before(new HTMLElement('span', {}), new HTMLElement('p', {}));
+					root.childNodes.length.should.eql(3);
+					root.childNodes[0].tagName.should.eql('SPAN');
+					root.childNodes[1].tagName.should.eql('P');
+				});
+				it('Should insert strings as TextNode', () => {
+					const root = parseHTML(`<section><div></div></section>`);
+					root.children[0].before(new HTMLElement('span', {}), 'foobar', new HTMLElement('p', {}));
+					root.childNodes.length.should.eql(4);
+					root.childNodes[1].should.be.an.instanceof(TextNode);
+					root.childNodes[1].text.should.eql('foobar');
+				});
+				it('Should set the parent correctly', () => {
+					const root = parseHTML(`<section><div></div></section>`);
+					root.firstElementChild.before('foobar');
+					root.firstElementChild.parentNode.should.eql(root);
+				});
+				it('Should be removed from previous trees', () => {
+					const root1 = parseHTML(`<section><div></div></section>`);
+					const root2 = parseHTML(`<section><div></div></section>`);
+					const section1 = root1.firstElementChild;
+					const section2 = root2.firstElementChild;
+					const div1 = section1.firstElementChild;
+					section2.before(div1);
+					section1.childNodes.length.should.eql(0);
+					root2.childNodes.length.should.eql(2);
+					div1.parentNode.should.eql(root2);
+				});
+			});
+			describe('#after', () => {
+				it('Should insert multiple nodes in order', () => {
+					const root = parseHTML(`<section><div></div></section>`);
+					root.children[0].after(new HTMLElement('span', {}), 'foobar', new HTMLElement('p', {}));
+					root.childNodes.length.should.eql(4);
+					root.childNodes[1].tagName.should.eql('SPAN');
+					root.childNodes[2].should.be.an.instanceof(TextNode);
+					root.childNodes[3].tagName.should.eql('P');
+				});
+				it('Should set the parent correctly', () => {
+					const root = parseHTML(`<section><div></div></section>`);
+					root.firstElementChild.after('foobar');
+					root.lastElementChild.parentNode.should.eql(root);
+				});
+			});
+			describe('#prepend', () => {
+				it('Should insert multiple nodes in order', () => {
+					const root = parseHTML(`<section><div></div><div></div></section>`);
+					const section = root.firstElementChild;
+					section.prepend(new HTMLElement('span', {}), 'foobar', new HTMLElement('p', {}));
+					section.childNodes.length.should.eql(5);
+					section.childNodes[0].tagName.should.eql('SPAN');
+					section.childNodes[1].should.be.an.instanceof(TextNode);
+					section.childNodes[2].tagName.should.eql('P');
+				});
+				it('Should set the parent correctly', () => {
+					const root = parseHTML(`<section></section>`);
+					const section = root.firstElementChild;
+					section.prepend('foobar');
+					section.childNodes[0].parentNode.should.eql(section);
+				});
+			});
+			describe('#append', () => {
+				it('Should insert multiple nodes in order', () => {
+					const root = parseHTML(`<section><div></div><div></div></section>`);
+					const section = root.firstElementChild;
+					section.append(new HTMLElement('span', {}), 'foobar', new HTMLElement('p', {}));
+					section.childNodes.length.should.eql(5);
+					section.childNodes[2].tagName.should.eql('SPAN');
+					section.childNodes[3].should.be.an.instanceof(TextNode);
+					section.childNodes[4].tagName.should.eql('P');
+				});
+				it('Should set the parent correctly', () => {
+					const root = parseHTML(`<section></section>`);
+					const section = root.firstElementChild;
+					section.append('foobar');
+					section.childNodes[0].parentNode.should.eql(section);
+				});
+			});
+		});
+
 		describe('#removeChild', function () {
-			it('shoud remove child node', function () {
+			it('should remove child node', function () {
 				const html = '<a><b></b></a>';
 				const root = parseHTML(html);
 				const a = root.firstChild;
@@ -590,7 +674,7 @@ describe('HTML Parser', function () {
 				a.removeChild(b);
 				a.childNodes.length.should.eql(0);
 			});
-			it('shoud not remove child node which does not exist', function () {
+			it('should not remove child node which does not exist', function () {
 				const html = '<a><b><c></c></b></a>';
 				const root = parseHTML(html);
 				const a = root.firstChild;
@@ -632,12 +716,12 @@ describe('HTML Parser', function () {
 				const root = parseHTML(`
 					<section>
 						<div data-ignore="true"></div>
-	
+
 						<div id="suit" data-ignore="true">
 							<div data-ignore="false"></div>
 							<div data-ignore="false"></div>
 						</div>
-	
+
 						<div data-ignore="true"></div>
 					</section>
 				`);
@@ -684,6 +768,25 @@ describe('HTML Parser', function () {
 				delete root.querySelector('section').childNodes[1];
 
 				root.getElementsByTagName('div').length.should.eql(2);
+			});
+		});
+
+		describe('#children', () => {
+			const root = parseHTML(`
+				<div></div>
+				Text
+				<div></div>
+				foobar
+				baz
+				<div></div>
+			`);
+			it('All children are `HTMLElement`', () => {
+				root.children.forEach(child => {
+					child.should.be.an.instanceof(HTMLElement);
+				});
+			});
+			it('Correct length', () => {
+				root.children.length.should.eql(3);
 			});
 		});
 	});


### PR DESCRIPTION
Hi,
First of all, thanks for writing this library, it's a really clever yet simple DOM abstraction!

I implemented some methods that I felt were missing from the `HTMLElement`. They are commonly used in the actual [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Element) and thus provide better compatibility with other backend DOM abstractions as well (in my case, I switched from deno-dom to node-html-parser, and I had to shim some of these).

- `get children()` (only `HTMLElement` children)
- `get firstElementChild()`
- `get lastElementchild()`
- `get childElementCount()`
- `before(...nodes)`
- `after(...nodes)`
- `prepend(...nodes)`
- `append(...nodes)`

The last four are now the base operations. `insertAdjacentHTML` and `appendChild` use them and they are tested accordingly.

README documentation is also included :v: 