### PR TITLE
fix: preserve consecutive backslashes in attribute values

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -158,11 +158,11 @@ export default class HTMLElement extends Node {
 			return 'null';
 		}
 
-		return JSON.stringify(attr.replace(/"/g, '&quot;'))
-			.replace(/([^\\])\\t/g, '$1\t')
-			.replace(/([^\\])\\n/g, '$1\n')
-			.replace(/([^\\])\\r/g, '$1\r')
-			.replace(/([^\\])\\/g, '$1');
+		// Attribute values are literal text: only the double quote needs
+		// escaping (as &quot;). The previous JSON.stringify-based approach
+		// doubled backslashes and then failed to undo runs of consecutive
+		// backslashes, corrupting values such as "C:\\Users\\me".
+		return `"${attr.replace(/"/g, '&quot;')}"`;
 	}
 
 	/**

--- a/test/tests/quoteattributes.js
+++ b/test/tests/quoteattributes.js
@@ -28,4 +28,12 @@ describe('quote attributes', function () {
       foo: '[{"bar":"baz"}]',
     });
   });
+
+  it('preserves consecutive backslashes through a setAttribute round-trip', function () {
+    const root = parse('<div></div>');
+    const div = root.firstChild;
+    const value = 'C:\\\\Users\\\\me'; // C:\\Users\\me (doubled backslashes)
+    div.setAttribute('path', value);
+    parse(div.toString()).firstChild.getAttribute('path').should.equal(value);
+  });
 });


### PR DESCRIPTION
### Problem

`quoteAttribute` serializes an attribute value with `JSON.stringify` (which doubles every backslash) and then tries to undo the doubling with `.replace(/([^\\])\\/g, '$1')`. That regex requires a non-backslash before each backslash and matches non-overlapping, so it cannot collapse a run of **consecutive** backslashes. The value gains an extra backslash on every serialization and no longer round-trips:

```js
const { parse } = require('node-html-parser'); // 8.0.2

const el = parse('<div></div>').firstChild;
el.setAttribute('path', 'C:\\Users\\me');      // value: C:\Users\me  (single)  -> OK
el.setAttribute('path', 'C:\\\\Users\\\\me');  // value: C:\\Users\\me (doubled)
el.toString();                                 // <div path="C:\\\Users\\\me">  (extra backslash)
parse(el.toString()).firstChild.getAttribute('path'); // 'C:\\\Users\\\me'  (corrupted)
```

The single-backslash case fixed in #306 works; consecutive backslashes (e.g. a JSON-escaped Windows path or a regex stored in an attribute) were the unhandled residual.

### Fix

Attribute values are literal text, so only the double quote needs escaping (as `&quot;`). Quote the value directly instead of round-tripping it through `JSON.stringify`. This preserves any number of backslashes and still escapes embedded quotes (the #62 behaviour).

### Test

Added a round-trip assertion for an attribute value with consecutive backslashes. It fails before the change and passes after; the full suite (263 passing) and lint are green.