### PR TITLE
fix: serialize attributes through quoteAttribute in removeWhitespace

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -464,8 +464,9 @@ export default class HTMLElement extends Node {
 		// remove whitespace between attributes
 		const attrs = Object.keys(this.rawAttributes)
 			.map((key) => {
-				const val = this.rawAttributes[key];
-				return `${key}=${JSON.stringify(val)}`;
+				const val = this.quoteAttribute(this.rawAttributes[key]);
+				if (val === 'null' || val === '""') return key;
+				return `${key}=${val}`;
 			})
 			.join(' ');
 		this.rawAttrs = attrs;

--- a/test/tests/html.js
+++ b/test/tests/html.js
@@ -300,6 +300,15 @@ describe('HTML Parser', function () {
 				parseHTML('<p>\t\nHello\n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql('HelloWorld!');
 				parseHTML('<p>\t\n  Hello \n\t<em>World</em>!</p>').removeWhitespace().firstChild.text.should.eql(' Hello World!');
 			});
+
+			it('should preserve consecutive backslashes in attribute values', function () {
+				const html = '<a data-x="C:\\\\Users\\\\me">x</a>';
+				parseHTML(html).removeWhitespace().firstChild.toString().should.eql(html);
+			});
+
+			it('should preserve valueless attributes', function () {
+				parseHTML('<input disabled required>').removeWhitespace().firstChild.toString().should.eql('<input disabled required>');
+			});
 		});
 
 		describe('#rawAttributes', function () {


### PR DESCRIPTION
`removeWhitespace()` rebuilds `rawAttrs` to drop the whitespace between attributes, but it serializes each value with `JSON.stringify(val)` instead of going through `quoteAttribute`, the helper the other write paths use. That leaves it with the two bugs the helper already handles, so `removeWhitespace()` corrupts attribute values:

- **Consecutive backslashes get doubled.** `<a data-x="C:\Users\me">` becomes `<a data-x="C:\\Users\\me">` and no longer round-trips. This is the same problem fixed for the setter paths in #306 and #309 (`JSON.stringify` doubling backslashes), but `removeWhitespace` kept the old serialization.
- **Valueless attributes gain a `null` value.** `<input disabled required>` becomes `<input disabled=null required=null>`, because `JSON.stringify(null)` is the string `"null"`. `setAttribute`/`removeAttribute` already guard this with `if (val === 'null' || val === '""') return name`.

The fix routes the value through `quoteAttribute` and applies the same valueless-attribute guard the three other serialization sites (`setAttribute`, `removeAttribute`, `setAttributes`) already use, so all four paths agree.

I added two regression tests under `#removeWhitespace()`. Without the change they fail with the corrupted output above; with it the suite passes.
