### PR TITLE
Avoid O(n^2) text node append during parse (fixes #317)

### DIFF
--- a/src/nodes/html.ts
+++ b/src/nodes/html.ts
@@ -1118,14 +1118,16 @@ export function base_parse(data: string, options = {} as Partial<Options>) {
 		if (lastTextPos > -1) {
 			if (lastTextPos + matchLength < tagEndPos) {
 				const text = data.substring(lastTextPos, tagStartPos);
-				currentParent.appendChild(new TextNode(text, currentParent, createRange(lastTextPos, tagStartPos)));
+				// Pass a null parentNode: appendChild() sets it. Pre-setting it makes the
+				// node look attached, so remove() rescans the parent's childNodes (O(n^2)).
+				currentParent.appendChild(new TextNode(text, null, createRange(lastTextPos, tagStartPos)));
 			}
 		}
 
 		lastTextPos = markupPattern.lastIndex;
 
 		if (hasCDATA && matchText.startsWith('<![CDATA[')) {
-			currentParent.appendChild(new TextNode(matchText, currentParent, createRange(tagStartPos, tagEndPos)));
+			currentParent.appendChild(new TextNode(matchText, null, createRange(tagStartPos, tagEndPos)));
 			continue;
 		}
 
@@ -1138,7 +1140,7 @@ export function base_parse(data: string, options = {} as Partial<Options>) {
 			if (options.comment) {
 				// Only keep what is in between <!-- and -->
 				const text = data.substring(tagStartPos + 4, tagEndPos - 3);
-				currentParent.appendChild(new CommentNode(text, currentParent, createRange(tagStartPos, tagEndPos)));
+				currentParent.appendChild(new CommentNode(text, null, createRange(tagStartPos, tagEndPos)));
 			}
 			continue;
 		}
@@ -1195,7 +1197,7 @@ export function base_parse(data: string, options = {} as Partial<Options>) {
 				if (element_should_be_ignore(tagName)) {
 					const text = data.substring(tagEndPos, textEndPos);
 					if (text.length > 0 && /\S/.test(text)) {
-						currentParent.appendChild(new TextNode(text, currentParent, createRange(tagEndPos, textEndPos)));
+						currentParent.appendChild(new TextNode(text, null, createRange(tagEndPos, textEndPos)));
 					}
 				}
 

--- a/test/tests/issues/317.js
+++ b/test/tests/issues/317.js
@@ -1,0 +1,31 @@
+const { parse } = require('@test/test-target');
+
+function elapsed(fn) {
+	const start = process.hrtime.bigint();
+	fn();
+	return Number(process.hrtime.bigint() - start) / 1e6; // ms
+}
+
+describe('issue 317', function () {
+	it('parses alternating text/element siblings correctly', function () {
+		const root = parse('<div>a<br>b<br></div>');
+		const div = root.firstChild;
+		div.childNodes.length.should.eql(4);
+		div.childNodes.map((node) => node.parentNode).should.eql([div, div, div, div]);
+		root.toString().should.eql('<div>a<br>b<br></div>');
+	});
+
+	it('scales linearly when text and element siblings alternate under one parent', function () {
+		this.timeout(20000);
+		const build = (n) => `<div>${'line<br>'.repeat(n)}</div>`;
+		// Warm up so JIT state is comparable between the two measurements.
+		parse(build(2000));
+
+		const small = Math.max(elapsed(() => parse(build(4000))), 1);
+		const large = elapsed(() => parse(build(32000)));
+
+		// 8x the input should cost roughly 8x the time. Quadratic behaviour costs ~64x;
+		// allow generous headroom for a noisy CI box while still failing on O(n^2).
+		(large / small).should.be.below(24);
+	});
+});


### PR DESCRIPTION
Fixes #317.

## Root cause

`base_parse` constructed text and comment nodes with `parentNode` already set to `currentParent`, then passed them to `appendChild`:

```js
currentParent.appendChild(new TextNode(text, currentParent, createRange(lastTextPos, tagStartPos)));
```

`appendChild` → `append` → `resolveInsertable` calls `node.remove()` so that moving an already-attached node into a new parent works. `remove()` short-circuits only when `parentNode` is null:

```js
public remove() {
    if (this.parentNode) {
        const children = this.parentNode.childNodes;
        this.parentNode.childNodes = children.filter((child) => this !== child);
        this.parentNode = null;
    }
    return this;
}
```

With the parent pre-assigned, a brand-new node looks attached, so `remove()` rebuilt the parent's entire `childNodes` array via `filter` even though the node was never in it. That is O(k) scanning plus one fresh array allocation per appended text node. A parent accumulating n text siblings therefore costs O(n²) comparisons and O(n²) copied slots, with n large short-lived arrays driving the disproportionate GC the issue reported.

This is also exactly why the homogeneous cases in the issue stayed linear: the `HTMLElement` construction site already passes `null`, so element appends never entered the `filter` branch; and `<span>x</span><br>` put each text node into a still-empty `span` (k = 0).

Instrumented `remove()` on 9.0.1, counting elements visited by the `filter`:

```
n=1000  filterElemVisits=999000     (8.4ms)
n=2000  filterElemVisits=3998000    (27.4ms)
n=4000  filterElemVisits=15996000   (84.9ms)
n=8000  filterElemVisits=63992000   (162.0ms)
```

Quadruples per input doubling.

## Fix

Pass `null` as the `parentNode` argument at the four parse-time construction sites (three `TextNode`, one `CommentNode`), matching what the `HTMLElement` site already does. `appendChild` assigns the real parent through `resetParent` immediately afterwards, so node identity, `parentNode` and `range` are all unchanged — only the redundant `remove()` scan disappears.

## Results

Parsing `<div>${'line<br>'.repeat(n)}</div>`:

| n | before | after |
|---|---|---|
| 1000 | 9.9 ms | 1.8 ms |
| 2000 | 28.3 ms | 1.9 ms |
| 4000 | 51.0 ms | 3.2 ms |
| 8000 | 153.9 ms | 5.6 ms |
| 16000 | 904.8 ms | 10.9 ms |
| 32000 | 3991.4 ms | 19.7 ms |
| 64000 | — | 33.4 ms |

Roughly 200× at n=32000, and scaling is linear.

## Verification

- `mocha --recursive ./test/tests` with `TEST_TARGET=src`: 265 passing before the change, 267 passing after (the two new tests), 0 failing.
- `eslint ./src/*.ts ./src/**/*.ts` clean.
- Behaviour spot-checked on `<div>a<br>b<!--c--><![CDATA[d]]></div>` and on a `<script>` block-text element: `parentNode` correct on every child, `range` tuples byte-identical to before, `toString()` roundtrip exact.
- Added `test/tests/issues/317.js`. The scaling assertion fails on unpatched source (`expected 73.58 to be below 24`) and passes with the fix.

## Note on the remaining footgun

`resolveInsertable` unconditionally calling `remove()` means any caller that constructs a node with a pre-set `parentNode` and then appends it hits the same O(k) rescan, and `remove()` reallocates the sibling array rather than splicing in place. Making detachment genuinely O(1) needs child-index bookkeeping on `Node`, which is a much larger change, so I left it alone and only fixed the parser's own hot path. Happy to look at that separately if you want it.